### PR TITLE
[FEAT] Q&A 게시글 작성에 이미지 삭제 기능 추가

### DIFF
--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -6,18 +6,16 @@ export default function NavBar() {
 
   return (
     <nav className='nav-bar'>
-      {navString.map((v, i) => {
+      {navString.map((nav, i) => {
         return (
           <div key={i} className='nav-item'>
-            {location.pathname === v[0] ? (
-              <Link key={i} className='nav-selected-link' to={v[0]}>
-                {v[1]}
-              </Link>
-            ) : (
-              <Link key={i} className='nav-link' to={v[0]}>
-                {v[1]}
-              </Link>
-            )}
+            <Link
+              key={i}
+              className={location.pathname === nav[0] ? 'nav-selected-link' : 'nav-link'}
+              to={nav[0]}
+            >
+              {nav[1]}
+            </Link>
           </div>
         );
       })}

--- a/src/components/common/PlusButton.tsx
+++ b/src/components/common/PlusButton.tsx
@@ -1,12 +1,19 @@
-import { Link } from 'react-router-dom';
+interface PlusButtonPros {
+  padding?: string;
+  onClick?: () => void;
+}
 
-export default function PlusButton() {
+export default function PlusButton({ padding, onClick }: PlusButtonPros) {
+  const plusButtonStyle = {
+    padding,
+  };
+
   return (
-    <div className='plus-button'>
-      <Link className='main-link' to='/qna'>
+    <div className='plus-button' style={plusButtonStyle} onClick={onClick}>
+      <div className='main-link'>
         <div className='plus-button-circle'>&gt;</div>
         <div>더보기</div>
-      </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/common/WriteButton.tsx
+++ b/src/components/common/WriteButton.tsx
@@ -1,0 +1,13 @@
+import { BsPencil } from 'react-icons/bs';
+
+interface WriteButtonProps {
+  onClick?: () => void;
+}
+
+export default function WriteButton({ onClick }: WriteButtonProps) {
+  return (
+    <div onClick={onClick} className='write-button'>
+      <BsPencil size='20' color='white' />
+    </div>
+  );
+}

--- a/src/components/main/ExpertContainer.tsx
+++ b/src/components/main/ExpertContainer.tsx
@@ -10,7 +10,7 @@ export default function ExpertContainer() {
           .map((_, i) => {
             return <MainExpertCard key={i} />;
           })}
-        <PlusButton />
+        <PlusButton padding='15px 0px 0px 5px' />
       </div>
     </>
   );

--- a/src/components/main/QnaContainer.tsx
+++ b/src/components/main/QnaContainer.tsx
@@ -1,11 +1,12 @@
 import MainQnaCard from 'components/main/MainQnaCard';
 import PlusButton from 'components/common/PlusButton';
-
+import { useNavigate } from 'react-router-dom';
 interface QnaContainerProps {
   title: string;
 }
 
 export default function QnaContainer({ title }: QnaContainerProps) {
+  const nav = useNavigate();
   return (
     <>
       <div className='qna-title'>{title}</div>
@@ -15,7 +16,11 @@ export default function QnaContainer({ title }: QnaContainerProps) {
           .map((_, i) => {
             return <MainQnaCard key={i} />;
           })}
-        <PlusButton />
+        <PlusButton
+          onClick={() => {
+            nav('qna');
+          }}
+        />
       </div>
     </>
   );

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -12,7 +12,7 @@ export default function Main() {
   const [transX, setTransX] = useState(0);
 
   return (
-    <div className='main'>
+    <div className='main-container'>
       <div className='carousel-div'>
         <div
           className='carousel-container'

--- a/src/pages/QnA/index.tsx
+++ b/src/pages/QnA/index.tsx
@@ -1,11 +1,13 @@
 import { QnaCard } from 'components';
+import WriteButton from 'components/common/WriteButton';
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 export default function Qna() {
   const [QnaList, setQnaList] = useState<JSX.Element[]>(Array(6).fill(<QnaCard />));
   const [lastCardRef, inView] = useInView();
+  const nav = useNavigate();
 
   useEffect(() => {
     setQnaList((prev) => [...prev, ...Array(6).fill(<QnaCard />)]);
@@ -23,6 +25,11 @@ export default function Qna() {
         return <Link to='detail'>{qnaItem}</Link>;
       })}
       <div ref={lastCardRef}></div>
+      <WriteButton
+        onClick={() => {
+          nav('newpost');
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/QnaNewPost/index.tsx
+++ b/src/pages/QnaNewPost/index.tsx
@@ -4,9 +4,9 @@ import FooterButton from 'components/common/FooterButton';
 import { useState, FormEvent } from 'react';
 import { categoryItem } from 'constants/qnaNewPost';
 import checkExtensions from 'utils/checkExtensions';
-import axios from 'axios';
 import checkFileSize from 'utils/checkFileSize';
 
+import { IoMdRemoveCircleOutline } from 'react-icons/io';
 interface PostInfo {
   title: string;
   content: string;
@@ -63,6 +63,10 @@ export default function NewPost() {
     }
   };
 
+  const onClickRemoveHandler = (index: number) => {
+    setImgFile((prev) => [...prev.filter((_, i) => i !== index)]);
+    setFilePreview((prev) => [...prev.filter((_, i) => i !== index)]);
+  };
   const onSendData = () => {
     const formData = new FormData();
     formData.append('requiest', new Blob([JSON.stringify(postInfo)], { type: 'application/json' }));
@@ -71,7 +75,7 @@ export default function NewPost() {
 
   return (
     <div>
-      <div className='qna-newpost-main' onChange={onChangeHandler}>
+      <div className='qna-newpost-container' onChange={onChangeHandler}>
         <InputTilte isRequire={true}>카테고리 </InputTilte>
         <div className='category-container'>
           {categoryItem.map((category, i) => {
@@ -117,7 +121,14 @@ export default function NewPost() {
             .fill(0)
             .map((_, i) => {
               return filePreview[i] !== undefined ? (
-                <img key={i} className='image-item' src={filePreview[i]} alt='error' />
+                <div className='image-item'>
+                  <img key={i} className='image-item' src={filePreview[i]} alt='error' />
+                  <IoMdRemoveCircleOutline
+                    size='25px'
+                    className='remove-image'
+                    onClick={() => onClickRemoveHandler(i)}
+                  />
+                </div>
               ) : (
                 <div key={i} className='image-item' />
               );

--- a/src/pages/QnaNewPost/index.tsx
+++ b/src/pages/QnaNewPost/index.tsx
@@ -5,8 +5,10 @@ import { useState, FormEvent } from 'react';
 import { categoryItem } from 'constants/qnaNewPost';
 import checkExtensions from 'utils/checkExtensions';
 import checkFileSize from 'utils/checkFileSize';
-
 import { IoMdRemoveCircleOutline } from 'react-icons/io';
+import CustomHeader from 'components/common/CustomHeader';
+import { useNavigate } from 'react-router-dom';
+
 interface PostInfo {
   title: string;
   content: string;
@@ -21,6 +23,8 @@ export default function NewPost() {
   });
   const [filePreview, setFilePreview] = useState<string[]>([]);
   const [imgFile, setImgFile] = useState<File[]>([]);
+  const nav = useNavigate();
+
   const onChangeHandler = (e: FormEvent<HTMLElement>) => {
     if ((e.target as HTMLInputElement).id === 'imgFile') {
       return;
@@ -75,6 +79,13 @@ export default function NewPost() {
 
   return (
     <div>
+      <CustomHeader
+        left={'<'}
+        center='Q&A 등록'
+        onClickLeft={() => {
+          nav(-1);
+        }}
+      />
       <div className='qna-newpost-container' onChange={onChangeHandler}>
         <InputTilte isRequire={true}>카테고리 </InputTilte>
         <div className='category-container'>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -33,8 +33,6 @@ export default function Router() {
       </Route>
 
       <Route path='/' element={<LayoutWithoutNav />}>
-        <Route path='/qna/newpost' element={<NewPost />} />
-
         {/* 마이페이지 메뉴 */}
         <Route path='/mypage/experts' element={<AuthExpert />} />
         <Route path='/mypage/posts' element={<MyActivityInfo />} />
@@ -52,7 +50,9 @@ export default function Router() {
       <Route path='/' element={<LayoutWithoutHeader />}>
         <Route path='/auth/login' element={<Login />} />
         <Route path='/auth/Signup' element={<Signup />} />
+
         <Route path='/qna/detail' element={<QnaDetail />} />
+        <Route path='/qna/newpost' element={<NewPost />} />
       </Route>
     </Routes>
   );

--- a/src/styles/components/_write-button.scss
+++ b/src/styles/components/_write-button.scss
@@ -1,0 +1,14 @@
+@use '../abstracts' as *;
+
+.write-button {
+  position: fixed;
+  background-color: $primary-color;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50px;
+  height: 50px;
+  bottom: 80px;
+  right: 30px;
+  border-radius: 50px;
+}

--- a/src/styles/components/index.scss
+++ b/src/styles/components/index.scss
@@ -11,3 +11,4 @@
 @forward 'carousel';
 @forward 'modal';
 @forward 'delete-image';
+@forward 'write-button';

--- a/src/styles/pages/_home.scss
+++ b/src/styles/pages/_home.scss
@@ -62,12 +62,13 @@
   display: flex;
   overflow: scroll;
   align-items: center;
-
+  gap: 6px;
   &::-webkit-scrollbar {
     display: none;
   }
 
   .main-expert-card {
+    margin-left: 5px;
     min-width: 220px;
     height: 80px;
     display: flex;
@@ -75,7 +76,6 @@
     border-radius: 10px;
     align-items: center;
     margin-top: 15px;
-    margin-left: 5px;
 
     .main-expert-card-img {
       width: 50px;

--- a/src/styles/pages/_home.scss
+++ b/src/styles/pages/_home.scss
@@ -1,9 +1,9 @@
 @use '../abstracts' as *;
 
-.main {
+.main-container {
   padding: 10px;
   @include header-gap;
-  margin-bottom: 58px;
+  @include footer-gap;
 }
 
 .button-container {

--- a/src/styles/pages/_newpost.scss
+++ b/src/styles/pages/_newpost.scss
@@ -8,7 +8,7 @@
   border-radius: 10px;
 }
 
-.qna-newpost-main {
+.qna-newpost-container {
   padding: 15px 30px 30px 30px;
   position: relative;
   width: 100vw;
@@ -48,6 +48,13 @@
 .image-item {
   @include qna-image-box($color-gray04);
   object-fit: cover;
+  min-width: 65px;
+  height: 68px;
+}
+
+.image-item-add-button {
+  min-width: 65px;
+  height: 68px;
 }
 
 .image-item-add-button {
@@ -55,6 +62,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.image-add-item {
+  display: none;
 }
 
 .image-add-item-plus {
@@ -89,4 +100,12 @@
     outline: none;
     border: 1.5px solid $primary-color;
   }
+}
+
+.remove-image {
+  position: relative;
+  z-index: 10000;
+  top: -70px;
+  left: 40px;
+  color: white;
 }

--- a/src/styles/pages/_qna-detail.scss
+++ b/src/styles/pages/_qna-detail.scss
@@ -1,9 +1,9 @@
 @use '../abstracts' as *;
 
 .qna-detail-container {
+  @include footer-gap;
   padding: 0px 35px;
   width: 100vw;
-  margin-bottom: 80px;
 
   .title {
     font-size: 14px;

--- a/src/styles/pages/_qna.scss
+++ b/src/styles/pages/_qna.scss
@@ -20,7 +20,7 @@
     @include font-styles(13px, 300, $color-gray01);
     padding-left: 10px;
     margin-top: 8px;
-
+    margin-bottom: 10px;
     span {
       @include font-styles(13px, 700, $color-gray01);
     }
@@ -37,6 +37,7 @@
 
   .title {
     @include ellipsis-text;
+    @include font-styles(14px, 700, $color-gray01);
     line-height: 2rem;
     width: auto;
   }


### PR DESCRIPTION
## 해당 이슈
#10 #12 

## 구현 사항

https://user-images.githubusercontent.com/62174495/228282881-aa911288-2ae5-494f-b2e6-ff62c9d97468.mp4

제거 아이콘은 빨간색으로 했다가 너무 안이뻐서 흰색으로 일단 해놨습니다. 혹시 원하시는 색깔 있으시면 반영하겠습니다^^.

https://user-images.githubusercontent.com/62174495/228283363-c6574d2d-4fce-41ce-8795-e2b321f45f1a.mp4

Q&A 게시글 목록에서 글쓰기 버튼 추가하였습니다.

그 외 자잘한 마진이나 스타일 수정하였습니다^^..