### PR TITLE
[FEAT] 회원가입 페이지 기능 구현 완료

### DIFF
--- a/src/components/common/Message.tsx
+++ b/src/components/common/Message.tsx
@@ -10,7 +10,7 @@ export default function Message({ isWarning, alignRight, children }: MessageProp
   return (
     <strong
       className={`message ${isWarning ? 'warning-message' : 'correct-message'} ${
-        alignRight && 'align-right'
+        alignRight ? 'align-right' : ''
       }`}
     >
       {children}

--- a/src/components/signup/InputField.tsx
+++ b/src/components/signup/InputField.tsx
@@ -2,6 +2,7 @@ import { InputBox, InputTitle, Message } from 'components';
 import { FieldName, Membership } from 'pages/Signup';
 
 interface InputFieldProps {
+  inputRef?: React.RefObject<HTMLInputElement>;
   className?: string;
   type?: string;
   placeholder: string;
@@ -10,34 +11,47 @@ interface InputFieldProps {
   registrationMembership: Membership;
   initWarningMessage: Membership;
   warningMessage: Membership;
+  showCorrectMessage?: { account: boolean; email: boolean };
   children?: React.ReactNode;
   onChange: (target: FieldName) => (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export default function InputField({
+  inputRef,
   className,
   target,
   title,
   registrationMembership,
   initWarningMessage,
   warningMessage,
+  showCorrectMessage,
   onChange,
   children,
   type = 'text',
   placeholder = '',
 }: InputFieldProps) {
+  const isAccountOrEmail = target === 'account' || target === 'email';
+
   return (
     <>
       <div className='title-message'>
         <InputTitle isRequire>{title}</InputTitle>
-        <Message isWarning alignRight>
-          {registrationMembership[target] === ''
-            ? initWarningMessage[target]
-            : warningMessage[target]}
-        </Message>
+        {isAccountOrEmail && showCorrectMessage?.[target] ? (
+          <Message>
+            사용 가능한 {(target === 'account' && '아이디') || (target === 'email' && '이메일')}
+            입니다.
+          </Message>
+        ) : (
+          <Message isWarning alignRight>
+            {registrationMembership[target] === ''
+              ? initWarningMessage[target]
+              : warningMessage[target]}
+          </Message>
+        )}
       </div>
       <div className={className ? className : ''}>
         <InputBox
+          inputRef={inputRef}
           onChange={onChange(target)}
           required
           width='100%'

--- a/src/components/signup/InputField.tsx
+++ b/src/components/signup/InputField.tsx
@@ -1,5 +1,6 @@
 import { InputBox, InputTitle, Message } from 'components';
-import { FieldName, Membership } from 'pages/Signup';
+
+import { FieldName, Membership } from 'types/signupTypes';
 
 interface InputFieldProps {
   inputRef?: React.RefObject<HTMLInputElement>;

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,140 +1,22 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Button, Checkbox, FooterButton } from 'components';
 import InputField from 'components/signup/InputField';
 
 import { isValidId, isValidName, isValidPw, post } from 'utils';
-import { isValidEmail } from 'utils/validate/checkSignup';
-import { useNavigate } from 'react-router-dom';
+import {
+  isValidEmail,
+  validateAccount,
+  validateEmail,
+  validatePassword,
+  validateReEnterPassword,
+  validateusername,
+} from 'utils/validate/checkSignup';
+import { initMembershipValues, initWarningMessage } from 'utils/initialValues/signup';
 
-/**
- * 타입 선언
- */
-export type FieldName = 'account' | 'password' | 'reEnterPassword' | 'username' | 'email';
-
-export interface Membership {
-  account: string;
-  password: string;
-  reEnterPassword: string;
-  username: string;
-  email: string;
-  isNotificated?: boolean;
-}
-
-export interface ValidChecker {
-  account: boolean;
-  password: boolean;
-  reEnterPassword: boolean;
-  username: boolean;
-  email: boolean;
-}
-
-interface SigunupFormRefs {
-  account: React.RefObject<HTMLInputElement>;
-  password: React.RefObject<HTMLInputElement>;
-  reEnterPassword: React.RefObject<HTMLInputElement>;
-  username: React.RefObject<HTMLInputElement>;
-  email: React.RefObject<HTMLInputElement>;
-}
-
-interface Error {
-  response?: {
-    data: any;
-    status: number;
-    resultCode?: string;
-  };
-}
-
-/**
- * 초기화 변수 정의
- */
-
-const initMembershipValues = {
-  account: '',
-  password: '',
-  reEnterPassword: '',
-  username: '',
-  email: '',
-  isNotificated: true,
-};
-
-const initWarningMessage: Membership = {
-  account: '아이디를 입력해주세요.',
-  password: '비밀번호를 입력해주세요.',
-  reEnterPassword: '비밀번호를 다시 입력해주세요.',
-  username: '이름을 입력해주세요.',
-  email: '이메일을 입력해주세요.',
-};
-
-/**
- * 유효성 검사 함수
- */
-const validateAccount = (value: string) => {
-  if (isValidId(value)) {
-    return {
-      state: true,
-      msg: '중복 확인을 해주세요.',
-    };
-  }
-
-  return {
-    state: false,
-    msg: '영문으로 시작하며 4~10글자 영문/숫자여야 해요.',
-  };
-};
-
-const validatePassword = (value: string) => {
-  if (isValidPw(value)) {
-    return {
-      state: true,
-      msg: '',
-    };
-  }
-
-  return { state: false, msg: '6글자 이상 영어, 숫자, 특수문자를 포함해주세요.' };
-};
-
-const validateReEnterPassword = (password: string, reEnterPassword: string) => {
-  if (password === reEnterPassword) {
-    return {
-      state: true,
-      msg: '',
-    };
-  }
-
-  return {
-    state: false,
-    msg: '비밀번호가 일치하지 않아요.',
-  };
-};
-
-const validateusername = (value: string) => {
-  if (isValidName(value)) {
-    return {
-      state: true,
-      msg: '',
-    };
-  }
-
-  return {
-    state: false,
-    msg: '2~4글자 한글만 입력할 수 있어요.',
-  };
-};
-
-const validateEmail = (value: string) => {
-  if (isValidEmail(value)) {
-    return {
-      state: true,
-      msg: '중복 확인을 해주세요.',
-    };
-  }
-
-  return {
-    state: false,
-    msg: '올바른 이메일 형식을 입력해주세요.',
-  };
-};
+import { ApiError } from 'types/errorsTypes';
+import { FieldName, SigunupFormRefs, ValidChecker } from 'types/signupTypes';
 
 /**
  * Signup 페이지
@@ -261,7 +143,7 @@ export default function Signup() {
         });
       }
     } catch (err: unknown) {
-      const Error = err as Error;
+      const Error = err as ApiError;
       if (Error.response?.status === 400) {
         console.error('이미 존재하는 아이디 또는 이메일입니다.');
 
@@ -298,8 +180,8 @@ export default function Signup() {
           navigate('/');
         }
       } catch (err: unknown) {
-        const Error = err as Error;
-        console.error(Error.response?.status);
+        const error = err as ApiError;
+        console.error(error.response?.status);
       }
     } else setInputsToShake(() => []);
   };

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -3,19 +3,20 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { Button, Checkbox, FooterButton } from 'components';
 import InputField from 'components/signup/InputField';
 
-import { isValidId, isValidName, isValidPw } from 'utils';
+import { isValidId, isValidName, isValidPw, post } from 'utils';
 import { isValidEmail } from 'utils/validate/checkSignup';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * 타입 선언
  */
-export type FieldName = 'account' | 'password' | 'reEnterPassword' | 'userName' | 'email';
+export type FieldName = 'account' | 'password' | 'reEnterPassword' | 'username' | 'email';
 
 export interface Membership {
   account: string;
   password: string;
   reEnterPassword: string;
-  userName: string;
+  username: string;
   email: string;
   isNotificated?: boolean;
 }
@@ -24,19 +25,35 @@ export interface ValidChecker {
   account: boolean;
   password: boolean;
   reEnterPassword: boolean;
-  userName: boolean;
+  username: boolean;
   email: boolean;
+}
+
+interface SigunupFormRefs {
+  account: React.RefObject<HTMLInputElement>;
+  password: React.RefObject<HTMLInputElement>;
+  reEnterPassword: React.RefObject<HTMLInputElement>;
+  username: React.RefObject<HTMLInputElement>;
+  email: React.RefObject<HTMLInputElement>;
+}
+
+interface Error {
+  response?: {
+    data: any;
+    status: number;
+    resultCode?: string;
+  };
 }
 
 /**
  * 초기화 변수 정의
  */
 
-const initMembershipValues: Membership = {
+const initMembershipValues = {
   account: '',
   password: '',
   reEnterPassword: '',
-  userName: '',
+  username: '',
   email: '',
   isNotificated: true,
 };
@@ -45,7 +62,7 @@ const initWarningMessage: Membership = {
   account: '아이디를 입력해주세요.',
   password: '비밀번호를 입력해주세요.',
   reEnterPassword: '비밀번호를 다시 입력해주세요.',
-  userName: '이름을 입력해주세요.',
+  username: '이름을 입력해주세요.',
   email: '이메일을 입력해주세요.',
 };
 
@@ -53,44 +70,126 @@ const initWarningMessage: Membership = {
  * 유효성 검사 함수
  */
 const validateAccount = (value: string) => {
-  if (isValidId(value)) return '중복확인을 해주세요.';
-  return '영문으로 시작하며 4~10글자 영문/숫자여야 해요.';
+  if (isValidId(value)) {
+    return {
+      state: true,
+      msg: '중복 확인을 해주세요.',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '영문으로 시작하며 4~10글자 영문/숫자여야 해요.',
+  };
 };
 
 const validatePassword = (value: string) => {
-  if (isValidPw(value)) return '';
-  return '6글자 이상 영어, 숫자, 특수문자를 포함해주세요.';
+  if (isValidPw(value)) {
+    return {
+      state: true,
+      msg: '',
+    };
+  }
+
+  return { state: false, msg: '6글자 이상 영어, 숫자, 특수문자를 포함해주세요.' };
 };
 
 const validateReEnterPassword = (password: string, reEnterPassword: string) => {
-  if (password === reEnterPassword) return '';
-  return '비밀번호가 일치하지 않아요.';
+  if (password === reEnterPassword) {
+    return {
+      state: true,
+      msg: '',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '비밀번호가 일치하지 않아요.',
+  };
 };
 
-const validateUserName = (value: string) => {
-  if (isValidName(value)) return '';
-  return '2~4글자 한글만 입력할 수 있어요.';
+const validateusername = (value: string) => {
+  if (isValidName(value)) {
+    return {
+      state: true,
+      msg: '',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '2~4글자 한글만 입력할 수 있어요.',
+  };
 };
 
 const validateEmail = (value: string) => {
-  if (isValidEmail(value)) return '';
-  return '올바른 이메일 형식을 입력해주세요.';
+  if (isValidEmail(value)) {
+    return {
+      state: true,
+      msg: '중복 확인을 해주세요.',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '올바른 이메일 형식을 입력해주세요.',
+  };
 };
 
 /**
  * Signup 페이지
  */
 export default function Signup() {
+  const navigate = useNavigate();
+
   const [registrationMembership, setRegistrationMembership] = useState(initMembershipValues);
+  const [isCorrectFormData, setIsCorrectFormData] = useState<ValidChecker>({
+    account: false,
+    email: false,
+    password: false,
+    reEnterPassword: false,
+    username: false,
+  });
   const [warningMessage, setWarningMessage] = useState(initWarningMessage);
+  const [showCorrectMessage, setShowCorrectMessage] = useState({
+    account: false,
+    email: false,
+  });
+  const [disabledDuplicationButton, setDisabledDuplicationButton] = useState({
+    account: true,
+    email: true,
+  });
   const [inputsToShake, setInputsToShake] = useState<FieldName[]>([]);
 
   const [isMounted, setIsMounted] = useState(false);
 
-  const inputRef = useRef<HTMLInputElement>(null);
+  const formRefs = useRef<SigunupFormRefs>({
+    account: useRef(null),
+    username: useRef(null),
+    email: useRef(null),
+    password: useRef(null),
+    reEnterPassword: useRef(null),
+  });
 
+  /**
+   * 인풋 박스 change 이벤트
+   */
   const onChangeInput = (target: FieldName) => (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
+
+    setIsCorrectFormData((prev) => {
+      // 인풋 값 변경 시 해당 인풋이 제대로 작성되지 않을 수 있으므로 false로 변경합니다.
+      // 비밀번호의 경우 확인 인풋도 false가 되어야 하므로 분기처리하였습니다.
+      if (target === 'password') {
+        return {
+          ...prev,
+          [target]: false,
+          reEnterPassword: false,
+        };
+      }
+
+      return { ...prev, [target]: false };
+    });
 
     setRegistrationMembership((prev) => {
       return { ...prev, [target]: value };
@@ -98,26 +197,34 @@ export default function Signup() {
 
     setWarningMessage((prev) => {
       if (target === 'account') {
-        return { ...prev, [target]: validateAccount(value) };
+        setShowCorrectMessage((prev) => {
+          return { ...prev, account: false };
+        });
+
+        return { ...prev, [target]: validateAccount(value).msg };
       }
 
       if (target === 'password') {
-        return { ...prev, [target]: validatePassword(value) };
+        return { ...prev, [target]: validatePassword(value).msg };
       }
 
       if (target === 'reEnterPassword') {
         const password = registrationMembership.password;
         const reEnterPassword = value;
 
-        return { ...prev, [target]: validateReEnterPassword(password, reEnterPassword) };
+        return { ...prev, [target]: validateReEnterPassword(password, reEnterPassword).msg };
       }
 
-      if (target === 'userName') {
-        return { ...prev, [target]: validateUserName(value) };
+      if (target === 'username') {
+        return { ...prev, [target]: validateusername(value).msg };
       }
 
       if (target === 'email') {
-        return { ...prev, [target]: validateEmail(value) };
+        setShowCorrectMessage((prev) => {
+          return { ...prev, email: false };
+        });
+
+        return { ...prev, [target]: validateEmail(value).msg };
       }
 
       return { ...prev, [target]: '' };
@@ -130,22 +237,71 @@ export default function Signup() {
     });
   };
 
-  const onClickCheckDuplicate = (target: string) => async (e: React.MouseEvent) => {
-    //TODO: API 문서 답변 오면 수정할 부분
-    // 중복확인 버튼을 눌렀을 때 중복 아이디인 경우 '이미 존재하는 아이디입니다.'
-    // 중복 아이디가 아닌 경우 '사용가능한 아이디입니다'
-  };
   /**
+   * * 아이디/이메일 중복 체크
+   */
+  const onClickCheckDuplicate = (target: 'account' | 'email') => async (e: React.MouseEvent) => {
+    const body = {
+      [target]: registrationMembership[target],
+    };
+
+    if (!registrationMembership[target]) return;
+    try {
+      const res = await post({
+        endpoint: `users/duplicate-${target}`,
+        body,
+      });
+
+      if (res.status === 200) {
+        setIsCorrectFormData((prev) => {
+          return { ...prev, [target]: true };
+        });
+        setShowCorrectMessage((prev) => {
+          return { ...prev, [target]: true };
+        });
+      }
+    } catch (err: unknown) {
+      const Error = err as Error;
+      if (Error.response?.status === 400) {
+        console.error('이미 존재하는 아이디 또는 이메일입니다.');
+
+        setWarningMessage((prev) => {
+          return {
+            ...prev,
+            [target]: `이미 존재하는 ${target === 'account' ? '아이디' : '이메일이'}에요.`,
+          };
+        });
+      }
+    }
+  };
+
+  /**
+   * * 회원가입 POST 요청
    * ✨ 회원가입 버튼 클릭 후 동작
    * 입력한 인풋이 유효하지 않으면 shake 효과 적용 후 리턴
    * 유효하면 서버로 POST 요청합니다.
    */
 
-  const onSubmitRegister = () => {
+  const onSubmitRegister = async () => {
     // 유효하지 않으면 shake 효과 추가 후 return
-    // 유효하면 POST
+    const isCorrectInputValues = Object.entries(isCorrectFormData).every(([_, value]) => value);
 
-    setInputsToShake(() => []);
+    if (isCorrectInputValues) {
+      // 유효하면 POST
+      try {
+        const res = await post({
+          endpoint: 'users/join',
+          body: registrationMembership,
+        });
+        if (res.status === 201) {
+          window.alert('퍼디 회원이 되신 것을 환영해요!'); // *임시 메시지
+          navigate('/');
+        }
+      } catch (err: unknown) {
+        const Error = err as Error;
+        console.error(Error.response?.status);
+      }
+    } else setInputsToShake(() => []);
   };
 
   useEffect(() => {
@@ -155,77 +311,95 @@ export default function Signup() {
   useEffect(() => {
     //TODO: 리팩토링
     if (isMounted) {
-      if (!isValidId(registrationMembership.account)) {
+      if (!isValidId(registrationMembership.account) || !isCorrectFormData.account) {
         if (inputsToShake.includes('account')) return;
+        formRefs.current.account.current?.focus();
         return setInputsToShake((prev) => [...prev, 'account']);
       }
 
-      if (!isValidPw(registrationMembership.password)) {
+      if (!isValidPw(registrationMembership.password) || !isCorrectFormData.password) {
         if (inputsToShake.includes('password')) return;
+        formRefs.current.password.current?.focus();
         return setInputsToShake((prev) => [...prev, 'password']);
       }
 
-      if (!(registrationMembership.password === registrationMembership.reEnterPassword)) {
+      if (
+        !(registrationMembership.password === registrationMembership.reEnterPassword) ||
+        !isCorrectFormData.reEnterPassword
+      ) {
         if (inputsToShake.includes('reEnterPassword')) return;
+        formRefs.current.reEnterPassword.current?.focus();
         return setInputsToShake((prev) => [...prev, 'reEnterPassword']);
       }
 
-      if (!isValidName(registrationMembership.userName)) {
-        if (inputsToShake.includes('userName')) return;
-        return setInputsToShake((prev) => [...prev, 'userName']);
+      if (!isValidName(registrationMembership.username) || !isCorrectFormData.username) {
+        if (inputsToShake.includes('username')) return;
+        formRefs.current.username.current?.focus();
+        return setInputsToShake((prev) => [...prev, 'username']);
       }
 
-      if (!isValidPw(registrationMembership.email)) {
+      if (!isValidPw(registrationMembership.email) || !isCorrectFormData.email) {
         if (inputsToShake.includes('email')) return;
+        formRefs.current.email.current?.focus();
         return setInputsToShake((prev) => [...prev, 'email']);
       }
     }
   }, [inputsToShake]);
 
   /**
-   * 예외처리 목록 (id)
-   * 1. 빈 값일 때
-   * ✅ : 아이디를 입력해주세요.
-   * 2. 아이디가 영문자로 시작하지 않을 때
-   * 3. 4~10자가 아닐 때
-   * 4. 영문/숫자가 포함되어 있지 않을 때
-   * ✅: 영문자로 시작하는 4~10자 영문/숫자를 입력해주세요.
-   * TODO: 5. 중복확인 버튼을 누르지 않았을 때
-   *
-   * (password)
-   * 1. 빈 값일 때
-   * ✅: 비밀번호를 입력해주세요.
-   * 2. 6글자 이하일 때
-   * 3. 영어, 숫자, 특수문자가 포함되지 않았을 때
-   * ✅: 6글자 이상 영어, 숫자, 특수문자를 포함해주세요.
-   *
-   * (re-password)
-   * 1. 빈 값일 때
-   * ✅: 비밀번호를 다시 입력해주세요.
-   * 2. password와 일치하지 않을 때
-   * ✅: 비밀번호와 일치하지 않아요.
-   *
-   * (name)
-   * 1. 빈 값일 때
-   * ✅ : 이름을 입력해주세요.
-   * 2. 한글이 아닐 때
-   * ✅: 한글만 입력할 수 있어요.
-   *
-   * (email)
-   * 1. 빈 값일 때
-   * ✅: 이메일을 입력해주세요.
-   * 2. a@b.c 와 같은 형태가 아닐 때
-   * 3. 영문, 숫자, '@', '.'를 제외한 다른 문자가 있을 때
-   * ✅ : 이메일 형식이 올바르지 않아요.
-   * TODO: 4. 중복확인 안했을 때
-   * :
+   * 아이디/이메일이 유효하면 중복 확인 버튼을 활성화합니다.
    */
+  useEffect(() => {
+    if (isValidId(registrationMembership.account)) {
+      setDisabledDuplicationButton((prev) => {
+        return { ...prev, account: false };
+      });
+    } else {
+      setDisabledDuplicationButton((prev) => {
+        return { ...prev, account: true };
+      });
+    }
 
-  // !디버깅
-  console.log(registrationMembership);
+    if (isValidEmail(registrationMembership.email)) {
+      setDisabledDuplicationButton((prev) => {
+        return { ...prev, email: false };
+      });
+    } else {
+      setDisabledDuplicationButton((prev) => {
+        return { ...prev, email: true };
+      });
+    }
+  }, [registrationMembership.account, registrationMembership.email]);
 
   useEffect(() => {
-    if (inputRef.current) inputRef.current.focus();
+    // 사용자가 중간에 인풋 값을 바꾸는 경우 유효한지 확인 후
+    // 유효할 경우 isCorrectFormData 값을 true로 갱신합니다.
+
+    if (registrationMembership.password === registrationMembership.reEnterPassword) {
+      setIsCorrectFormData((prev) => {
+        return { ...prev, reEnterPassword: true };
+      });
+    }
+
+    if (isValidPw(registrationMembership.password)) {
+      setIsCorrectFormData((prev) => {
+        return { ...prev, password: true };
+      });
+    }
+
+    if (isValidName(registrationMembership.username)) {
+      setIsCorrectFormData((prev) => {
+        return { ...prev, username: true };
+      });
+    }
+  }, [
+    registrationMembership.password,
+    registrationMembership.reEnterPassword,
+    registrationMembership.username,
+  ]);
+
+  useEffect(() => {
+    if (formRefs.current) formRefs.current.account.current?.focus();
   }, []);
 
   useEffect(() => {
@@ -233,10 +407,11 @@ export default function Signup() {
       setWarningMessage((prev) => {
         return { ...prev, reEnterPassword: '비밀번호가 일치하지 않아요.' };
       });
-    } else
+    } else {
       setWarningMessage((prev) => {
         return { ...prev, reEnterPassword: '' };
       });
+    }
   }, [registrationMembership.password]);
 
   return (
@@ -248,6 +423,7 @@ export default function Signup() {
       </h2>
       <div className='signup-datas'>
         <InputField
+          inputRef={formRefs.current.account}
           className={`duplicate-check-container ${
             inputsToShake.includes('account') ? 'shake' : ''
           }`}
@@ -258,11 +434,18 @@ export default function Signup() {
           registrationMembership={registrationMembership}
           initWarningMessage={initWarningMessage}
           warningMessage={warningMessage}
+          showCorrectMessage={showCorrectMessage}
         >
-          <Button onClick={onClickCheckDuplicate('account')}>중복 확인</Button>
+          <Button
+            disabled={disabledDuplicationButton.account}
+            onClick={onClickCheckDuplicate('account')}
+          >
+            중복 확인
+          </Button>
         </InputField>
 
         <InputField
+          inputRef={formRefs.current.password}
           onChange={onChangeInput}
           className={`${inputsToShake.includes('password') ? 'shake' : ''}`}
           placeholder='비밀번호를 입력해주세요.'
@@ -275,6 +458,7 @@ export default function Signup() {
         />
 
         <InputField
+          inputRef={formRefs.current.reEnterPassword}
           onChange={onChangeInput}
           className={`${inputsToShake.includes('reEnterPassword') ? 'shake' : ''}`}
           placeholder='비밀번호를 다시 입력해주세요.'
@@ -287,10 +471,11 @@ export default function Signup() {
         />
 
         <InputField
+          inputRef={formRefs.current.username}
           onChange={onChangeInput}
-          className={`${inputsToShake.includes('userName') ? 'shake' : ''}`}
+          className={`${inputsToShake.includes('username') ? 'shake' : ''}`}
           placeholder='이름을 입력해주세요.'
-          target='userName'
+          target='username'
           title='이름'
           registrationMembership={registrationMembership}
           initWarningMessage={initWarningMessage}
@@ -298,6 +483,7 @@ export default function Signup() {
         />
 
         <InputField
+          inputRef={formRefs.current.email}
           className={`duplicate-check-container ${inputsToShake.includes('email') ? 'shake' : ''}`}
           onChange={onChangeInput}
           placeholder='이메일을 입력해주세요.'
@@ -306,8 +492,14 @@ export default function Signup() {
           registrationMembership={registrationMembership}
           initWarningMessage={initWarningMessage}
           warningMessage={warningMessage}
+          showCorrectMessage={showCorrectMessage}
         >
-          <Button onClick={onClickCheckDuplicate('email')}>중복 확인</Button>
+          <Button
+            disabled={disabledDuplicationButton.email}
+            onClick={onClickCheckDuplicate('email')}
+          >
+            중복 확인
+          </Button>
         </InputField>
 
         <div className='notification'>

--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -15,16 +15,17 @@ $SM_SIZE: 100px;
   transition: all 0.2s;
   cursor: pointer;
 
+  &:hover {
+    background-color: $secondary-color02;
+  }
+
   &:disabled {
     cursor: auto;
+    background-color: $color-gray03;
   }
 
   &.sm {
     width: $SM_SIZE;
-  }
-
-  &:hover {
-    background-color: $secondary-color02;
   }
 
   &.outline {

--- a/src/types/errorsTypes.ts
+++ b/src/types/errorsTypes.ts
@@ -1,0 +1,7 @@
+export interface ApiError {
+  response?: {
+    data: any;
+    status: number;
+    resultCode?: string;
+  };
+}

--- a/src/types/signupTypes.ts
+++ b/src/types/signupTypes.ts
@@ -1,0 +1,26 @@
+export type FieldName = 'account' | 'password' | 'reEnterPassword' | 'username' | 'email';
+
+export interface Membership {
+  account: string;
+  password: string;
+  reEnterPassword: string;
+  username: string;
+  email: string;
+  isNotificated?: boolean;
+}
+
+export interface ValidChecker {
+  account: boolean;
+  password: boolean;
+  reEnterPassword: boolean;
+  username: boolean;
+  email: boolean;
+}
+
+export interface SigunupFormRefs {
+  account: React.RefObject<HTMLInputElement>;
+  password: React.RefObject<HTMLInputElement>;
+  reEnterPassword: React.RefObject<HTMLInputElement>;
+  username: React.RefObject<HTMLInputElement>;
+  email: React.RefObject<HTMLInputElement>;
+}

--- a/src/utils/axiosHelper.ts
+++ b/src/utils/axiosHelper.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
-const BACKEND_PORT_NUMBER = '8082';
-const SERVER_URL = `http://${window.location.hostname}:${BACKEND_PORT_NUMBER}/`;
+const SERVER_URL = `${process.env.REACT_APP_API_URL}:${process.env.REACT_APP_API_PORT}/`;
 
 interface GET {
   endpoint: string;
@@ -11,7 +10,7 @@ interface GET {
 
 interface POST {
   endpoint: string;
-  data?: Object;
+  body?: Object;
 }
 
 export async function get({ endpoint, params = '', queryString = '' }: GET) {
@@ -27,8 +26,8 @@ export async function get({ endpoint, params = '', queryString = '' }: GET) {
   );
 }
 
-export async function post({ endpoint, data }: POST) {
-  const bodyData = JSON.stringify(data);
+export async function post({ endpoint, body }: POST) {
+  const bodyData = JSON.stringify(body);
   console.log(`%cPOST 요청:${SERVER_URL}${endpoint}`, 'color: #296aba;');
   console.log(`%cPOST 요청 데이터: ${bodyData}`, 'color: #296aba;');
 

--- a/src/utils/initialValues/signup.ts
+++ b/src/utils/initialValues/signup.ts
@@ -1,0 +1,23 @@
+/**
+ * 회원가입 페이지
+ * 초기화 변수 정의
+ */
+
+import { Membership } from 'types/signupTypes';
+
+export const initMembershipValues = {
+  account: '',
+  password: '',
+  reEnterPassword: '',
+  username: '',
+  email: '',
+  isNotificated: true,
+};
+
+export const initWarningMessage: Membership = {
+  account: '아이디를 입력해주세요.',
+  password: '비밀번호를 입력해주세요.',
+  reEnterPassword: '비밀번호를 다시 입력해주세요.',
+  username: '이름을 입력해주세요.',
+  email: '이메일을 입력해주세요.',
+};

--- a/src/utils/validate/checkSignup.ts
+++ b/src/utils/validate/checkSignup.ts
@@ -18,3 +18,73 @@ export function isValidName(name: string) {
 export function isValidEmail(email: string) {
   return EMAIL_REG_EXP.test(email);
 }
+
+/**
+ * 유효성 검사 함수
+ */
+export const validateAccount = (value: string) => {
+  if (isValidId(value)) {
+    return {
+      state: true,
+      msg: '중복 확인을 해주세요.',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '영문으로 시작하며 4~10글자 영문/숫자여야 해요.',
+  };
+};
+
+export const validatePassword = (value: string) => {
+  if (isValidPw(value)) {
+    return {
+      state: true,
+      msg: '',
+    };
+  }
+
+  return { state: false, msg: '6글자 이상 영어, 숫자, 특수문자를 포함해주세요.' };
+};
+
+export const validateReEnterPassword = (password: string, reEnterPassword: string) => {
+  if (password === reEnterPassword) {
+    return {
+      state: true,
+      msg: '',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '비밀번호가 일치하지 않아요.',
+  };
+};
+
+export const validateusername = (value: string) => {
+  if (isValidName(value)) {
+    return {
+      state: true,
+      msg: '',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '2~4글자 한글만 입력할 수 있어요.',
+  };
+};
+
+export const validateEmail = (value: string) => {
+  if (isValidEmail(value)) {
+    return {
+      state: true,
+      msg: '중복 확인을 해주세요.',
+    };
+  }
+
+  return {
+    state: false,
+    msg: '올바른 이메일 형식을 입력해주세요.',
+  };
+};


### PR DESCRIPTION
## 회원가입 페이지

#3 

이제 퍼디 회원가입이 가능합니다~! 🤗
**기본적인 기능 구현은 완료되었습니다.**

**[구현 사항 정리]**
- 서버 POST 요청(아이디, 이메일 중복체크, 회원가입)
- 아이디/이메일 사용 가능할 경우 초록색 안내 메시지 노출
- 아이디/이메일 정규식 검사 통과 못할 경우 중복확인 버튼 비활성화
- input이 비어있는 상태에서 회원가입 버튼 클릭 시 포커싱

**앞으로 회원가입 페이지의 추가/변경 예정 사항은 다음과 같습니다.** 
- 허접한 회원가입 성공 `alert`창 변경
- 중복 코드 리팩토링
- 헤더 앱바 추가

별거 없을 줄 알았는데 메시지 변경하고 인터랙션 넣는 거 때문에
머리와 함께  로직이 꼬여서 생각보다 오래 걸렸네요오.. 😭

![Honeycam 2023-03-31 18-45-14](https://user-images.githubusercontent.com/48672106/229086525-7dc21f8b-aee6-4d73-ab75-7279ff8f26d5.gif)
