### PR TITLE
[FEAT] 로그인 페이지 기능 구현, 하단 앱바 코드 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import Router from './routes';
 

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 
 export default function NavBar() {
   const location = useLocation();
+  const isLoggedIn = sessionStorage.getItem('userToken');
 
   return (
     <nav className='nav-bar'>
@@ -12,7 +13,7 @@ export default function NavBar() {
             <Link
               key={i}
               className={location.pathname === path ? 'nav-selected-link' : 'nav-link'}
-              to={memberOnly ? '/auth/login' : path}
+              to={memberOnly && !isLoggedIn ? '/auth/login' : path}
             >
               {title}
             </Link>

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -1,4 +1,4 @@
-import { navItems } from '../../constants/navItem';
+import { navItems } from 'constants/navItem';
 import { Link, useLocation } from 'react-router-dom';
 
 export default function NavBar() {

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -1,4 +1,4 @@
-import { navString } from '../../constants/navItem';
+import { navItems } from '../../constants/navItem';
 import { Link, useLocation } from 'react-router-dom';
 
 export default function NavBar() {
@@ -6,15 +6,15 @@ export default function NavBar() {
 
   return (
     <nav className='nav-bar'>
-      {navString.map((nav, i) => {
+      {navItems.map(({ path, title, memberOnly }, i) => {
         return (
           <div key={i} className='nav-item'>
             <Link
               key={i}
-              className={location.pathname === nav[0] ? 'nav-selected-link' : 'nav-link'}
-              to={nav[0]}
+              className={location.pathname === path ? 'nav-selected-link' : 'nav-link'}
+              to={memberOnly ? '/auth/login' : path}
             >
-              {nav[1]}
+              {title}
             </Link>
           </div>
         );

--- a/src/constants/navItem.ts
+++ b/src/constants/navItem.ts
@@ -1,6 +1,28 @@
-export const navString: Array<string[]> = [
-  ['/', '홈'],
-  ['/qna', 'Q&A'],
-  ['/community', '커뮤니티'],
-  ['/auth/login', '마이페이지'],
+interface NavItem {
+  path: string;
+  title: string;
+  memberOnly: boolean;
+}
+
+export const navItems: NavItem[] = [
+  {
+    path: '/',
+    title: '홈',
+    memberOnly: false,
+  },
+  {
+    path: '/qna',
+    title: 'Q&A',
+    memberOnly: false,
+  },
+  {
+    path: '/community',
+    title: '커뮤니티',
+    memberOnly: false,
+  },
+  {
+    path: '/mypage',
+    title: '마이페이지',
+    memberOnly: true,
+  },
 ];

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,7 +1,7 @@
 import { FiSettings as SettingIcon } from 'react-icons/fi';
 import { AiOutlineQuestionCircle as QuestionIcon } from 'react-icons/ai';
 
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { Button } from 'components';
 
@@ -15,8 +15,21 @@ const TEMP_IMAGE_URL =
 export default function MyPage() {
   const [showModal, setShowModal] = useState(false);
 
+  const navigate = useNavigate();
+
   const onClickQuestionIcon = () => {
     setShowModal(true);
+  };
+
+  const onClickSetting = () => {
+    navigate('/mypage/profile');
+  };
+
+  const onClickMyPetInfo = () => {
+    //TODO: 펫 등록 여부를 확인할 필요가 있을듯함.
+    // 펫 등록된 유저:  /mypage/pets
+    // 미등록 유저 : /profile/pets
+    navigate('/mypage');
   };
 
   return (
@@ -24,11 +37,11 @@ export default function MyPage() {
       <div className='container'>
         <section className='profile'>
           <img className='profile-image' src={TEMP_IMAGE_URL} alt='프로필 이미지' />
-          <div className='setting'>
+          <div className='setting' onClick={onClickSetting}>
             <ProfileSettingButton />
           </div>
           <h3 className='nickname'>닉네임</h3>
-          <Button outline width='200px' height='35px'>
+          <Button onClick={onClickMyPetInfo} outline width='200px' height='35px'>
             내 펫 정보
           </Button>
         </section>

--- a/src/pages/MyProfileEditor/index.tsx
+++ b/src/pages/MyProfileEditor/index.tsx
@@ -4,25 +4,58 @@ import { IoMdClose as CloseIcon } from 'react-icons/io';
 import { Button, FooterButton, ImageUploader, InputBox, InputTitle, Message } from 'components';
 
 import checkExtensions from 'utils/checkExtensions';
+import { patch } from 'utils/axiosHelper';
 
 export default function MyProfileEditor() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [profileImg, setProfileImg] = useState('');
   const [showImgDeleteText, setShowImgDeleteText] = useState(false);
+  const [profileDatas, setProfileDatas] = useState<File | null>();
+  //TODO: 추후 닉네임 변경 값도 추가 해야 함.>
+
+  const fileSelectHandler = (files: FileList) => {
+    setProfileDatas(files?.[0]);
+  };
 
   const onChangeImage = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    if (!target.files) return;
+
     const files = target.files;
+    fileSelectHandler(files);
+
     const isValidImageExtensions = checkExtensions(files!);
     if (!isValidImageExtensions)
       return window.alert('.jpg, .jpeg, .png, .gif 확장자만 업로드 할 수 있어요.');
 
     const url = URL.createObjectURL(files![0]);
+
     setProfileImg(url);
   };
 
   const onClickDeleteImg = () => {
     setProfileImg('');
+    setProfileDatas(null);
+  };
+
+  console.log(profileDatas);
+
+  const onSubmitProfile = async () => {
+    // 파일이 변경된 경우에만 post요청
+    //TODO: 추후 닉네임 변경 유무도 필요함
+    if (!profileDatas) return window.alert('변경된 사항이 없어요!');
+
+    const formData = new FormData();
+    if (profileDatas) {
+      formData.append('file', profileDatas);
+    }
+
+    try {
+      const res = await patch({ endpoint: 'users/update-profile-image', body: formData });
+      console.log(res);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   useEffect(() => {
@@ -35,6 +68,7 @@ export default function MyProfileEditor() {
         <div
           onMouseEnter={() => setShowImgDeleteText(true)}
           onMouseLeave={() => setShowImgDeleteText(false)}
+          //TODO: 모바일 화면에서도 지원해야함
           className='img-container'
         >
           <img className='profile-img' src={profileImg} alt='프로필 사진' />
@@ -67,7 +101,7 @@ export default function MyProfileEditor() {
           <Button>중복확인</Button>
         </div>
       </div>
-      <FooterButton>변경하기</FooterButton>
+      <FooterButton onClick={onSubmitProfile}>변경하기</FooterButton>
     </div>
   );
 }

--- a/src/pages/PetProfileEditor/index.tsx
+++ b/src/pages/PetProfileEditor/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { IoMdClose as CloseIcon } from 'react-icons/io';
 
 import {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, Navigate, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
 import Layout from 'layouts';
 import LayoutWithoutHeader from 'layouts/LayoutWithoutHeader';
 import LayoutWithoutNav from 'layouts/LayoutWithoutNav';
@@ -22,40 +23,73 @@ import {
   MyProfileEditor,
 } from 'pages';
 
+const MEMBER_ONLY_PAGES = ['mypage', 'profile', 'expert', 'detail', 'newpost'];
+
 export default function Router() {
+  const isLoggedIn = sessionStorage.getItem('userToken');
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      const memberOnly = MEMBER_ONLY_PAGES.filter((page) => location.pathname.includes(page));
+
+      if (memberOnly.length) {
+        window.alert('회원전용 페이지입니다.');
+      }
+    }
+  }, [location]);
+
+  if (!isLoggedIn) {
+    return (
+      <Routes>
+        <Route element={<Layout />}>
+          <Route index element={<Main />} />
+          <Route path='qna' element={<Qna />} />
+          <Route path='community' element={<Community />} />
+        </Route>
+
+        <Route path='/' element={<LayoutWithoutHeader />}>
+          <Route path='auth/login' element={<Login />} />
+          <Route path='auth/Signup' element={<Signup />} />
+        </Route>
+
+        <Route path='*' element={<Navigate to='/' />} />
+      </Routes>
+    );
+  }
+
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route index path='/' element={<Main />} />
-        <Route path='/qna' element={<Qna />} />
-        <Route path='/community' element={<Community />} />
-
-        <Route path='/mypage' element={<MyPage />} />
+        <Route index element={<Main />} />
+        <Route path='qna' element={<Qna />} />
+        <Route path='community' element={<Community />} />
+        <Route path='mypage' element={<MyPage />} />
       </Route>
 
       <Route path='/' element={<LayoutWithoutNav />}>
         {/* 마이페이지 메뉴 */}
-        <Route path='/mypage/experts' element={<AuthExpert />} />
-        <Route path='/mypage/posts' element={<MyActivityInfo />} />
+        <Route path='mypage/experts' element={<AuthExpert />} />
+        <Route path='mypage/posts' element={<MyActivityInfo />} />
 
         {/* 프로필 작성 */}
-        <Route path='/profile/pets' element={<PetProfileEditor />} />
-        <Route path='/profile/experts' element={<ExpertProfileEditor />} />
+        {/* //TODO 전문가 프로필 작성 페이지는 전문가 회원 유형만 접근할 수 있도록 추가 필요 */}
+        <Route path='profile/pets' element={<PetProfileEditor />} />
+        <Route path='profile/experts' element={<ExpertProfileEditor />} />
 
         {/* 프로필 보기 */}
-        <Route path='/mypage/profile' element={<MyProfileEditor />} />
-        <Route path='/experts/:id' element={<ExpertProfile />} />
-        <Route path='/mypage/pets' element={<PetProfile />} />
+        <Route path='mypage/profile' element={<MyProfileEditor />} />
+        <Route path='experts/:id' element={<ExpertProfile />} />
+        <Route path='mypage/pets' element={<PetProfile />} />
       </Route>
 
       <Route path='/' element={<LayoutWithoutHeader />}>
-        <Route path='/auth/login' element={<Login />} />
-        <Route path='/auth/Signup' element={<Signup />} />
-
-        <Route path='/qna/detail' element={<QnaDetail />} />
-        <Route path='/qna/detail/write/answer' element={<QnaAnswer />} />
-        <Route path='/qna/newpost' element={<NewPost />} />
+        <Route path='qna/detail' element={<QnaDetail />} />
+        <Route path='qna/detail/write/answer' element={<QnaAnswer />} />
+        <Route path='qna/newpost' element={<NewPost />} />
       </Route>
+
+      <Route path='*' element={<Navigate to='/' />} />
     </Routes>
   );
 }

--- a/src/styles/layout/footer/_footer-app-bar.scss
+++ b/src/styles/layout/footer/_footer-app-bar.scss
@@ -32,9 +32,17 @@
   justify-content: center;
   align-items: center;
 
+  a {
+    @include center;
+    width: 100%;
+    height: 100%;
+    font-size: 1.2rem;
+  }
+
   .nav-selected-link {
     color: $primary-color;
     text-decoration-line: none;
+    font-weight: 600;
   }
 
   .nav-link {

--- a/src/styles/pages/_login.scss
+++ b/src/styles/pages/_login.scss
@@ -20,10 +20,9 @@
   }
 
   .inputs strong:first-child {
-    display: none;
-    position: absolute;
-    top: 0;
-    right: 0;
+    font-size: 1rem;
+    text-align: right;
+    width: 100%;
   }
 
   .find-and-join-container {

--- a/src/utils/axiosHelper.ts
+++ b/src/utils/axiosHelper.ts
@@ -10,7 +10,12 @@ interface GET {
 
 interface POST {
   endpoint: string;
-  body?: Object;
+  body?: object;
+}
+
+interface PATCH {
+  endpoint: string;
+  body?: object | File;
 }
 
 export async function get({ endpoint, params = '', queryString = '' }: GET) {
@@ -34,6 +39,14 @@ export async function post({ endpoint, body }: POST) {
   return axios.post(`${SERVER_URL}${endpoint}`, bodyData, {
     headers: {
       'Content-Type': 'application/json',
+      Authorization: sessionStorage.getItem('userToken'),
+    },
+  });
+}
+
+export async function patch({ endpoint, body }: PATCH) {
+  return axios.patch(`${SERVER_URL}${endpoint}`, body, {
+    headers: {
       Authorization: sessionStorage.getItem('userToken'),
     },
   });


### PR DESCRIPTION
## 로그인 페이지 기능 구현
#2 

**[구현 및 변경 사항]**
- 회원가입을 완료하여 유효한 회원인 경우 로그인 성공하며 발급된 token을 세션스토리지 저장
- 회원/비회원 유저에 따라 라우터 분기 처리 (혹시라도 테스트 중에 버그 있으면 알려주세요!)
- 하단 앱바의 경우 mypage는 회원, 비회원 시 라우트되는 페이지의 분기 처리가 필요한데 기존 코드는 확장성 이슈가 있어 리팩토링하였습니다...! 마음대로 수정해서 죄송합니다..! ㅠ.ㅠ

![Honeycam 2023-04-01 10-56-51](https://user-images.githubusercontent.com/48672106/229260438-3739ec34-6ee2-43de-82ef-68c8b4a49480.gif)
![Honeycam 2023-04-01 10-57-52](https://user-images.githubusercontent.com/48672106/229260439-ff091769-52d2-422d-abc3-6cc97d1fefbd.gif)
