### PR TITLE
[FEAT] Q&A 디테일 페이지 리펙토링 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,21 @@
 import { BrowserRouter } from 'react-router-dom';
 import Router from './routes';
+import { createContext } from 'react';
+import { useAuth } from 'hooks/useAuth';
+import { initUserInfo } from 'utils/initialValues/userInfo';
+
+export const UserInfo = createContext(initUserInfo);
 
 function App() {
+  const { decodedUserToken } = useAuth();
+  const userInfo = decodedUserToken();
+
   return (
-    <BrowserRouter>
-      <Router />
-    </BrowserRouter>
+    <UserInfo.Provider value={userInfo!}>
+      <BrowserRouter>
+        <Router />
+      </BrowserRouter>
+    </UserInfo.Provider>
   );
 }
 

--- a/src/components/common/FooterButton.tsx
+++ b/src/components/common/FooterButton.tsx
@@ -1,10 +1,11 @@
 interface FooterButtonProps {
   children?: React.ReactNode;
+  disabled?: boolean;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
-export default function FooterButton({ children, onClick }: FooterButtonProps) {
+export default function FooterButton({ children, disabled, onClick }: FooterButtonProps) {
   return (
-    <button onClick={onClick} className='footer-button'>
+    <button onClick={onClick} disabled={disabled} className='footer-button'>
       {children}
     </button>
   );

--- a/src/components/main/ExpertContainer.tsx
+++ b/src/components/main/ExpertContainer.tsx
@@ -10,7 +10,7 @@ export default function ExpertContainer() {
           .map((_, i) => {
             return <MainExpertCard key={i} />;
           })}
-        <PlusButton padding='15px 0px 0px 5px' />
+        <PlusButton padding='15px 0px 0px 7px' />
       </div>
     </>
   );

--- a/src/components/main/QnaContainer.tsx
+++ b/src/components/main/QnaContainer.tsx
@@ -14,20 +14,26 @@ export default function QnaContainer({ title, cardDataList }: QnaContainerProps)
   return (
     <>
       <div className='qna-title'>{title}</div>
-      <div className='main-qna-container'>
-        {cardDataList.map((cardData) => {
-          return (
-            <Link key={cardData.questionId} to={`qna/detail/${cardData.questionId}`}>
-              <MainQnaCard key={cardData.questionId} cardData={cardData} />
-            </Link>
-          );
-        })}
-        <PlusButton
-          padding='15px 0px 0px 10px'
-          onClick={() => {
-            nav('qna');
-          }}
-        />
+      <div className={`main-qna-container ${cardDataList.length === 0 ? 'zero-data' : ''}`}>
+        {cardDataList.length === 0 ? (
+          <div className='qna-zero-data'>데이터가 없습니다.</div>
+        ) : (
+          <>
+            {cardDataList.map((cardData) => {
+              return (
+                <Link key={cardData.questionId} to={`qna/detail/${cardData.questionId}`}>
+                  <MainQnaCard key={cardData.questionId} cardData={cardData} />
+                </Link>
+              );
+            })}
+            <PlusButton
+              padding='15px 0px 0px 10px'
+              onClick={() => {
+                nav('qna');
+              }}
+            />
+          </>
+        )}
       </div>
     </>
   );

--- a/src/components/main/QnaContainer.tsx
+++ b/src/components/main/QnaContainer.tsx
@@ -23,6 +23,7 @@ export default function QnaContainer({ title, cardDataList }: QnaContainerProps)
           );
         })}
         <PlusButton
+          padding='15px 0px 0px 10px'
           onClick={() => {
             nav('qna');
           }}

--- a/src/components/qnaDetail/Comment.tsx
+++ b/src/components/qnaDetail/Comment.tsx
@@ -9,11 +9,10 @@ import { Dispatch, SetStateAction } from 'react';
 const cn = classnames;
 interface CommentProps {
   answerData: AnswerInfo;
-  postWriterName?: string;
-  isSolved?: boolean;
-  isExport?: boolean;
-  isWriteUser?: boolean;
-  answerList?: AnswerInfo[];
+  isSolved: boolean;
+  isExport: boolean;
+  isPostUser: boolean;
+  isCommentWriteUser: boolean;
   setPostDataInfo: Dispatch<SetStateAction<PostDataInfo>>;
   setAnswerList: Dispatch<SetStateAction<AnswerInfo[]>>;
 }
@@ -21,9 +20,9 @@ interface CommentProps {
 export default function Comment({
   answerData,
   isSolved,
-  postWriterName,
-  isExport = false,
-  isWriteUser = false,
+  isPostUser,
+  isExport,
+  isCommentWriteUser,
   setPostDataInfo,
   setAnswerList,
 }: CommentProps) {
@@ -62,7 +61,7 @@ export default function Comment({
 
         <div className='user-roll-container'>
           <span className='user-roll'>{isExport ? '전문가 답변' : '사용자 답변'}</span>
-          {isWriteUser && (
+          {isCommentWriteUser && (
             <span className='user-roll'>
               <span>수정하기</span> | <span>삭제하기</span>
             </span>
@@ -71,7 +70,7 @@ export default function Comment({
       </div>
       <div className='comment-card-body'>{answerData.content}</div>
       <div className='comment-button'>
-        {!isSolved && (
+        {!isSolved && isPostUser && (
           <Button
             width='110px'
             height='25px'

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,11 +1,12 @@
 import Button from 'components/common/Button';
 import ExpertContainer from 'components/main/ExpertContainer';
 import QnaContainer from 'components/main/QnaContainer';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { get } from 'utils';
 import dragEvent from 'utils/dragEvent';
 import { MainQnaCardType } from 'types/qnaCardTypes';
 import { useNavigate } from 'react-router-dom';
+import { UserInfo } from 'App';
 const COLOR = ['red', 'black', 'green', 'gray', 'skyblue', 'yellow', 'pink'];
 const MAX_INDEX = COLOR.length - 1;
 
@@ -13,6 +14,7 @@ interface MainQnaList {
   popularQuestions: MainQnaCardType[];
   recentQuestions: MainQnaCardType[];
 }
+
 export default function Main() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [transX, setTransX] = useState(0);
@@ -24,6 +26,17 @@ export default function Main() {
     setMainQnaList(res.data.data);
   };
 
+  const userInfo = useContext(UserInfo);
+  console.log(userInfo);
+
+  const buttonOnClick = (movePage: () => void) => {
+    if (sessionStorage.getItem('userToken')) {
+      movePage();
+    } else {
+      alert('회원전용 페이지 입니다. 로그인 페이지로 이동합니다.');
+      nav('/auth/login');
+    }
+  };
   useEffect(() => {
     getMainData();
   }, []);
@@ -74,10 +87,10 @@ export default function Main() {
           </div>
 
           <div className='button-container'>
-            <Button onClick={() => nav('/qna/newpost')} width='160px'>
+            <Button onClick={() => buttonOnClick(() => nav('/auth/login'))} width='160px'>
               Q&A 질문하기
             </Button>
-            <Button onClick={() => nav('/profile/pets')} outline width='160px'>
+            <Button onClick={() => buttonOnClick(() => nav('/profile/pets'))} outline width='160px'>
               내 펫 등록하기
             </Button>
           </div>

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -6,8 +6,8 @@ import { get } from 'utils';
 import dragEvent from 'utils/dragEvent';
 import { MainQnaCardType } from 'types/qnaCardTypes';
 import { useNavigate } from 'react-router-dom';
-const COLOR = ['red', 'black', 'green', 'pink', 'skyblue'];
-const MAX_INDEX = 4;
+const COLOR = ['red', 'black', 'green', 'gray', 'skyblue', 'yellow', 'pink'];
+const MAX_INDEX = COLOR.length - 1;
 
 interface MainQnaList {
   popularQuestions: MainQnaCardType[];
@@ -58,7 +58,7 @@ export default function Main() {
           </div>
 
           <div className='circle-container'>
-            {Array(5)
+            {Array(MAX_INDEX + 1)
               .fill(0)
               .map((_, i) => {
                 return (

--- a/src/pages/QnA/index.tsx
+++ b/src/pages/QnA/index.tsx
@@ -40,13 +40,17 @@ export default function Qna() {
           내 반려견과 관련한 <span>질문/답변</span>을 작성해 보세요.
         </div>
       </div>
-      {qnaData?.map((data) => {
-        return (
-          <Link key={data.questionId} to={`detail/${data.questionId}`}>
-            <QnaCard key={data.questionId} qnaData={data} />
-          </Link>
-        );
-      })}
+      {qnaData.length === 0 ? (
+        <div className='qna-zero-data'>Q&A 게시글이 없습니다</div>
+      ) : (
+        qnaData?.map((data) => {
+          return (
+            <Link key={data.questionId} to={`detail/${data.questionId}`}>
+              <QnaCard key={data.questionId} qnaData={data} />
+            </Link>
+          );
+        })
+      )}
       <div ref={lastCardRef} />
       <WriteButton
         onClick={() => {

--- a/src/pages/QnA/index.tsx
+++ b/src/pages/QnA/index.tsx
@@ -42,12 +42,12 @@ export default function Qna() {
       </div>
       {qnaData?.map((data) => {
         return (
-          <Link to={`detail/${data.questionId}`}>
+          <Link key={data.questionId} to={`detail/${data.questionId}`}>
             <QnaCard key={data.questionId} qnaData={data} />
           </Link>
         );
       })}
-      <div ref={lastCardRef}></div>
+      <div ref={lastCardRef} />
       <WriteButton
         onClick={() => {
           nav('newpost');

--- a/src/pages/QnaAnswer/index.tsx
+++ b/src/pages/QnaAnswer/index.tsx
@@ -10,15 +10,17 @@ export default function QnaAnswer() {
   const location = useLocation();
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const [answer, setAnaswer] = useState('');
+
   useEffect(() => {
     textAreaRef.current?.focus();
   }, []);
+
   async function sendData() {
     const res = await post({
       endpoint: `questions/${location.state}/answers/write`,
       body: {
         content: answer,
-        postCategory: '2',
+        postCategory: '1',
       },
     });
 
@@ -29,6 +31,7 @@ export default function QnaAnswer() {
       alert('답변 작성 실패. 잠시 후 다시 시도해주세요');
     }
   }
+
   return (
     <>
       <CustomHeader
@@ -44,6 +47,7 @@ export default function QnaAnswer() {
         </InputTilte>
         <textarea
           className='text-body'
+          maxLength={500}
           defaultValue={answer}
           placeholder='답변을 입력해주세요.(최대 500자)'
           ref={textAreaRef}

--- a/src/pages/QnaAnswer/index.tsx
+++ b/src/pages/QnaAnswer/index.tsx
@@ -47,9 +47,9 @@ export default function QnaAnswer() {
         </InputTilte>
         <textarea
           className='text-body'
-          maxLength={500}
+          maxLength={100}
           defaultValue={answer}
-          placeholder='답변을 입력해주세요.(최대 500자)'
+          placeholder='답변을 입력해주세요.(최대 100자)'
           ref={textAreaRef}
           onChange={(e) => {
             setAnaswer(e.target.value);

--- a/src/pages/QnaDetail/index.tsx
+++ b/src/pages/QnaDetail/index.tsx
@@ -71,8 +71,19 @@ export default function QnaDetail() {
 
             <section className='body'>
               <div className='body-text'>{postDataInfo.content}</div>
-              {/* 
-              TODO: 내 펫 정보 등록 시 해당 정보 보여주기
+
+              <div className='img-box'>
+                {postDataInfo.imagePath !== '' ? (
+                  <>
+                    <img className='qna-image' src={postDataInfo.imagePath} />
+                  </>
+                ) : (
+                  <></>
+                )}
+              </div>
+
+              {/*
+                            TODO: 내 펫 정보 등록 시 해당 정보 보여주기
               <div className='tag-container'>
                 <span className='tag-item'>알레스카 말라뮤트</span>
                 <span className='tag-item'>중성화</span>

--- a/src/pages/QnaDetail/index.tsx
+++ b/src/pages/QnaDetail/index.tsx
@@ -1,12 +1,14 @@
 import CustomHeader from 'components/common/CustomHeader';
 import FooterButton from 'components/common/FooterButton';
 import Comment from 'components/qnaDetail/Comment';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 import { get } from 'utils';
 import { AnswerInfo, PostDataInfo } from 'types/commentTypes';
 import { initQnaDetail } from 'utils/initialValues/qnaDetail';
+import { UserInfo } from 'App';
+
 export default function QnaDetail() {
   const nav = useNavigate();
   const location = useLocation();
@@ -21,6 +23,9 @@ export default function QnaDetail() {
     setAnswerList(res.data.data.answerList);
   };
 
+  const userInfo = useContext(UserInfo);
+  console.log(userInfo);
+
   useEffect(() => {
     getDetailData();
   }, []);
@@ -29,17 +34,36 @@ export default function QnaDetail() {
 
   const AnsewerList = (answer: AnswerInfo) => {
     let isExport = answer.userRole === 'ROLE_USER' ? false : true;
+    let isPostUser = postDataInfo.nickname === userInfo.nickname;
+    const isCommentWriteUser = answer.nickname === userInfo.nickname;
+
     return (
       <Comment
         key={answer.id}
         answerData={answer}
-        postWriterName={postDataInfo?.nickname}
-        answerList={answerList}
         isExport={isExport}
+        isPostUser={isPostUser}
         isSolved={postDataInfo?.isSolved}
+        isCommentWriteUser={isCommentWriteUser}
         setPostDataInfo={setPostDataInfo}
         setAnswerList={setAnswerList}
       />
+    );
+  };
+
+  const IsFirstWriter = () => {
+    const isFirstWriter = !answerList.some((answer) => answer.nickname === userInfo.nickname);
+    return (
+      <FooterButton
+        onClick={() => {
+          isFirstWriter
+            ? nav('write/answer', { state: postId })
+            : nav('write/answer', { state: postId });
+          //TODO: 첫번째 작성자가 아니면 수정페이지로 이동 하기. 현재는 수정페이지 이동이 없어서 라우팅 주소가 같음
+        }}
+      >
+        {isFirstWriter ? '답글 입력하기' : '답글 수정하기'}
+      </FooterButton>
     );
   };
 
@@ -132,13 +156,7 @@ export default function QnaDetail() {
                 })}
             </section>
           </div>
-          <FooterButton
-            onClick={() => {
-              nav('write/answer', { state: postId });
-            }}
-          >
-            답글 입력하기
-          </FooterButton>
+          {postDataInfo.nickname === userInfo.nickname ? '' : IsFirstWriter()}
         </div>
       )}
     </>

--- a/src/pages/QnaNewPost/index.tsx
+++ b/src/pages/QnaNewPost/index.tsx
@@ -24,6 +24,8 @@ export default function NewPost() {
   const [filePreview, setFilePreview] = useState<string[]>([]);
   const [imgFile, setImgFile] = useState<File[]>([]);
   const nav = useNavigate();
+  const isVaildForm =
+    postInfo.content.length >= 1 && postInfo.content !== '' && postInfo.title.length >= 1;
 
   const onChangeHandler = (e: FormEvent<HTMLElement>) => {
     if ((e.target as HTMLInputElement).id === 'imgFile') {
@@ -143,7 +145,7 @@ export default function NewPost() {
             .fill(0)
             .map((_, i) => {
               return filePreview[i] !== undefined ? (
-                <div className='image-item'>
+                <div key={i} className='image-item'>
                   <img key={i} className='image-item' src={filePreview[i]} alt='error' />
                   <IoMdRemoveCircleOutline
                     size='25px'
@@ -164,7 +166,9 @@ export default function NewPost() {
           defaultValue={postInfo.content}
         ></textarea>
       </div>
-      <FooterButton onClick={onSendData}>등록하기</FooterButton>
+      <FooterButton onClick={onSendData} disabled={!isVaildForm}>
+        등록하기
+      </FooterButton>
     </div>
   );
 }

--- a/src/pages/QnaNewPost/index.tsx
+++ b/src/pages/QnaNewPost/index.tsx
@@ -161,6 +161,7 @@ export default function NewPost() {
         <InputTilte isRequire={true}> 내용 </InputTilte>
         <textarea
           id='content'
+          maxLength={500}
           className='text-body'
           placeholder='내용을 입력해주세요.(500자 이내)'
           defaultValue={postInfo.content}

--- a/src/styles/components/_footer-button.scss
+++ b/src/styles/components/_footer-button.scss
@@ -12,4 +12,8 @@
   font-size: 1.4rem;
   border: none;
   cursor: pointer;
+
+  &:disabled {
+    background-color: $color-gray02;
+  }
 }

--- a/src/styles/pages/_home.scss
+++ b/src/styles/pages/_home.scss
@@ -12,9 +12,7 @@
 }
 
 .qna-title {
-  font-weight: 700;
-  font-size: 16px;
-  color: $color-gray01;
+  @include font-styles(16px, 700, $color-gray01);
   padding-left: 10px;
   margin-top: 30px;
 }
@@ -24,9 +22,21 @@
   overflow: scroll;
   align-items: center;
 
+  &.zero-data {
+    display: block;
+    text-align: center;
+  }
+
   &::-webkit-scrollbar {
     display: none;
   }
+}
+
+.qna-zero-data {
+  font-size: 18px;
+  color: $color-gray02;
+  margin-top: 15px;
+  text-align: center;
 }
 
 .plus-button {
@@ -48,9 +58,7 @@
   }
 
   div {
-    font-weight: 400;
-    color: $color-gray01;
-    font-size: 10px;
+    @include font-styles(10px, 400, $color-gray01);
     padding-top: 5px;
     text-align: center;
     text-decoration: underline;
@@ -63,6 +71,7 @@
   overflow: scroll;
   align-items: center;
   gap: 6px;
+
   &::-webkit-scrollbar {
     display: none;
   }
@@ -90,16 +99,12 @@
       flex-direction: column;
 
       .description-title {
-        color: $color-gray01;
-        font-weight: 800;
-        font-size: 12px;
+        @include font-styles(12px, 800, $color-gray01);
         line-height: 20px;
       }
 
       .description-sub {
-        color: $color-gray01;
-        font-weight: 400;
-        font-size: 10px;
+        @include font-styles(10px, 400, $color-gray01);
         line-height: 15px;
       }
     }

--- a/src/styles/pages/_newpost.scss
+++ b/src/styles/pages/_newpost.scss
@@ -24,11 +24,9 @@
 }
 
 .category-item {
+  @include center();
   width: 94px;
   height: 30px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   border: 1px solid $color-gray04;
   color: $icon-color;
   border-radius: 10px;
@@ -59,9 +57,7 @@
 
 .image-item-add-button {
   @include qna-image-box($bg-color);
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  @include center();
 }
 
 .image-add-item {
@@ -69,17 +65,13 @@
 }
 
 .image-add-item-plus {
-  color: $color-gray02;
-  font-size: 25px;
-  font-weight: 600;
+  @include font-styles(25px, 600, $color-gray02);
   margin-bottom: 3px;
   text-align: center;
 }
 
 .image-add-item-text {
-  color: $color-gray02;
-  font-size: 8px;
-  font-weight: 700;
+  @include font-styles(8px, 700, $color-gray02);
 }
 
 .text-body {

--- a/src/styles/pages/_qna-detail.scss
+++ b/src/styles/pages/_qna-detail.scss
@@ -28,15 +28,11 @@
   }
 
   .post-date {
-    font-size: 10px;
-    font-weight: 400;
-    color: $color-gray02;
+    @include font-styles(10px, 400, $color-gray02);
   }
 
   .post-user {
-    font-size: 12px;
-    font-weight: 700;
-    color: $color-gray04;
+    @include font-styles(12px, 700, $color-gray04);
   }
 }
 
@@ -51,10 +47,8 @@
 }
 
 .body-text {
-  color: #000000;
-  font-weight: 300;
+  @include font-styles(14px, 300, #000000);
   margin: 20px 0px;
-  font-size: 14px;
   line-height: 23px;
 }
 
@@ -129,19 +123,15 @@
 
   .comment-card-user-info {
     .user {
-      color: $color-gray01;
-      font-weight: 700;
-      font-size: 16px;
+      @include font-styles(16px, 700, $color-gray01);
       margin-bottom: 10px;
     }
 
     .user-export {
+      @include font-styles(16px, 700, $primary-color);
       display: flex;
       align-items: center;
       gap: 5px;
-      color: $primary-color;
-      font-weight: 700;
-      font-size: 16px;
       margin-bottom: 10px;
     }
 
@@ -164,9 +154,7 @@
 }
 
 .comment-card-body {
-  color: #000000;
-  font-weight: 300;
-  font-size: 14px;
+  @include font-styles(14px, 300, #000000);
   line-height: 23px;
   margin-top: 20px;
 }

--- a/src/styles/pages/_qna-detail.scss
+++ b/src/styles/pages/_qna-detail.scss
@@ -168,4 +168,5 @@
   font-weight: 300;
   font-size: 14px;
   line-height: 23px;
+  margin-top: 20px;
 }

--- a/src/styles/pages/_qna-detail.scss
+++ b/src/styles/pages/_qna-detail.scss
@@ -61,7 +61,6 @@
 .img-box {
   display: flex;
   overflow: scroll;
-  min-width: 320px;
   gap: 15px;
   margin-bottom: 30px;
   justify-content: center;
@@ -80,7 +79,6 @@
 
 .tag-container {
   margin-top: 15px;
-  min-width: 320px;
   width: 100%;
   display: flex;
   overflow: scroll;

--- a/src/styles/pages/_qna-detail.scss
+++ b/src/styles/pages/_qna-detail.scss
@@ -39,11 +39,13 @@
     color: $color-gray04;
   }
 }
+
 .comment-zero {
   @include center;
   font-size: 15px;
   font-weight: 800;
 }
+
 .qna-divide-line {
   @include dividing-line(290px, $color-gray04);
 }
@@ -54,6 +56,26 @@
   margin: 20px 0px;
   font-size: 14px;
   line-height: 23px;
+}
+
+.img-box {
+  display: flex;
+  overflow: scroll;
+  min-width: 320px;
+  gap: 15px;
+  margin-bottom: 30px;
+  justify-content: center;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .qna-image {
+    width: 150px;
+    height: 150px;
+    object-fit: cover;
+    border-radius: 15px;
+  }
 }
 
 .tag-container {

--- a/src/styles/pages/_qna.scss
+++ b/src/styles/pages/_qna.scss
@@ -1,9 +1,9 @@
 @use '../abstracts' as *;
 
 .qna-container {
-  margin: 0 auto;
   @include header-gap;
   @include footer-gap;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   width: 90vw;
@@ -21,6 +21,7 @@
     padding-left: 10px;
     margin-top: 8px;
     margin-bottom: 10px;
+
     span {
       @include font-styles(13px, 700, $color-gray01);
     }

--- a/src/types/commentTypes.ts
+++ b/src/types/commentTypes.ts
@@ -16,4 +16,5 @@ export interface PostDataInfo {
   questionId: number;
   title: string;
   viewCount: number;
+  imagePath: string;
 }

--- a/src/utils/initialValues/qnaDetail.ts
+++ b/src/utils/initialValues/qnaDetail.ts
@@ -4,6 +4,7 @@ export const initQnaDetail = {
   createdDate: '',
   nickname: '',
   title: '',
+  imagePath: '',
   postCategory: 0,
   questionId: 0,
   viewCount: 0,

--- a/src/utils/initialValues/userInfo.ts
+++ b/src/utils/initialValues/userInfo.ts
@@ -1,0 +1,9 @@
+export const initUserInfo = {
+  auth: '',
+  email: '',
+  exp: 0,
+  id: 0,
+  nickname: '',
+  sub: '',
+  username: '',
+};


### PR DESCRIPTION
### 해당 이슈
#11 

### 


https://user-images.githubusercontent.com/62174495/229763838-3d9bbe7a-7925-4c1a-90aa-000944903104.mp4

1. 자기 자신이 쓴 글에는 답변을 달 수 없게 했습니다.
2. 다른 글에 자신이 쓴 답변에는 수정하기/삭제하기 버튼이 있는데 아직 구현은 되지 않았습니다.
3. 이미 답변을 작성하였다면 답변 수정하기, 답변을 작성하지 않았다면 답변 작성하기로 버튼에 문구가 바뀝니다.
4. 사용자 정보를 전역으로 쓸 수 있게끔 Context API 써봤는데 이유님이 원하시는 방향이 아닐 수도 있습니다. 이건 일단 제가 쓰려고 추가해둔건데 나중에 지우셔도 됩니다.