### PR TITLE
[FEAT, REFACTOR] context API 추가, axios Helper 함수 리팩토링, 일부 페이지 서버 통신 코드 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,16 @@ import { BrowserRouter } from 'react-router-dom';
 import Router from './routes';
 
 import { UserProvider } from 'context/UserContext';
+import { PetProvider } from 'context/PetContext';
 
 function App() {
   return (
     <UserProvider>
-      <BrowserRouter>
-        <Router />
-      </BrowserRouter>
+      <PetProvider>
+        <BrowserRouter>
+          <Router />
+        </BrowserRouter>
+      </PetProvider>
     </UserProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,14 @@
 import { BrowserRouter } from 'react-router-dom';
 import Router from './routes';
 
+import { UserProvider } from 'context/UserContext';
+
 function App() {
   return (
     <BrowserRouter>
-      <Router />
+      <UserProvider>
+        <Router />
+      </UserProvider>
     </BrowserRouter>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,11 @@ import { UserProvider } from 'context/UserContext';
 
 function App() {
   return (
-    <BrowserRouter>
-      <UserProvider>
+    <UserProvider>
+      <BrowserRouter>
         <Router />
-      </UserProvider>
-    </BrowserRouter>
+      </BrowserRouter>
+    </UserProvider>
   );
 }
 

--- a/src/context/PetContext.tsx
+++ b/src/context/PetContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+interface PetContextProps {
+  hasPet: boolean | null;
+  setHasPet: React.Dispatch<React.SetStateAction<boolean | null>>;
+}
+
+export const PetContext = createContext<PetContextProps>({
+  hasPet: false,
+  setHasPet: () => {},
+});
+
+export const PetProvider = ({ children }: { children: React.ReactNode }) => {
+  const [hasPet, setHasPet] = useState<boolean | null>(null);
+
+  const contextValue = {
+    hasPet,
+    setHasPet,
+  };
+
+  useEffect(() => {
+    //TODO: hasPet 값 넣는 부분 필요 마이페이지로 시작해야 할듯.
+  }, []);
+
+  return <PetContext.Provider value={contextValue}>{children}</PetContext.Provider>;
+};
+
+export const usePet = () => {
+  return useContext(PetContext);
+};

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,34 +1,70 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-import { useAuth } from 'hooks/useAuth';
-
 import { UserToken } from 'types/userTokenTypes';
+import decodeJWT from 'utils/decodeJWT';
 
 interface UserContextProps {
-  loggedInUser: UserToken | null;
-  setLoggedInUser: React.Dispatch<React.SetStateAction<UserToken | null>>;
+  token: string | null;
+  decodedToken: UserToken | null;
+  setToken: React.Dispatch<React.SetStateAction<string | null>>;
+  setDecodedToken: React.Dispatch<React.SetStateAction<UserToken | null>>;
 }
 
-const UserContext = createContext<UserContextProps>({
-  loggedInUser: null,
-  setLoggedInUser: () => {},
+export const UserContext = createContext<UserContextProps>({
+  token: null,
+  decodedToken: null,
+  setToken: () => {},
+  setDecodedToken: () => {},
 });
 
+const TOKEN_KEY = 'userToken';
+
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
-  const [loggedInUser, setLoggedInUser] = useState<UserToken | null>(null);
-  const { userDecodedToken } = useAuth();
+  const [token, setToken] = useState<string | null>(null);
+  const [decodedToken, setDecodedToken] = useState<UserToken | null>(null);
+
+  const contextValue = {
+    token,
+    decodedToken,
+    setToken,
+    setDecodedToken,
+  };
 
   useEffect(() => {
-    setLoggedInUser(() => userDecodedToken);
-  }, [userDecodedToken]);
+    const storedToken = sessionStorage.getItem(TOKEN_KEY);
+    if (storedToken) {
+      setToken(storedToken);
+    }
+  }, [token]);
 
-  return (
-    <UserContext.Provider value={{ loggedInUser, setLoggedInUser }}>
-      {children}
-    </UserContext.Provider>
-  );
+  useEffect(() => {
+    if (token) {
+      const decoded = decodeJWT(token);
+      setDecodedToken(() => decoded);
+    } else setDecodedToken(null);
+  }, [token]);
+
+  useEffect(() => {
+    const watchedStorageToken = (e: StorageEvent) => {
+      if (e.key !== TOKEN_KEY) return;
+
+      const userToken = e.newValue;
+      if (!userToken) {
+        setToken(() => null);
+        setDecodedToken(() => null);
+      }
+    };
+
+    window.addEventListener('storage', watchedStorageToken);
+
+    return () => {
+      window.removeEventListener('storage', watchedStorageToken);
+    };
+  }, []);
+
+  return <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>;
 };
 
-export const useUser = (): UserContextProps => {
-  return useContext<UserContextProps>(UserContext);
+export const useUser = () => {
+  return useContext(UserContext);
 };

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+import { useAuth } from 'hooks/useAuth';
+
+import { UserToken } from 'types/userTokenTypes';
+
+interface UserContextProps {
+  loggedInUser: UserToken | null;
+  setLoggedInUser: React.Dispatch<React.SetStateAction<UserToken | null>>;
+}
+
+const UserContext = createContext<UserContextProps>({
+  loggedInUser: null,
+  setLoggedInUser: () => {},
+});
+
+export const UserProvider = ({ children }: { children: React.ReactNode }) => {
+  const [loggedInUser, setLoggedInUser] = useState<UserToken | null>(null);
+  const { userDecodedToken } = useAuth();
+
+  useEffect(() => {
+    setLoggedInUser(() => userDecodedToken);
+  }, [userDecodedToken]);
+
+  return (
+    <UserContext.Provider value={{ loggedInUser, setLoggedInUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = (): UserContextProps => {
+  return useContext<UserContextProps>(UserContext);
+};

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,22 +1,35 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { UserToken } from 'types/userTokenTypes';
 
 import decodeJWT from 'utils/decodeJWT';
 
 export function useAuth() {
-  const [userToken, setUserToken] = useState<string | null>(sessionStorage.getItem('userToken'));
+  const [userToken, setUserToken] = useState<string | null>(null);
+  const [userDecodedToken, setUserDecodedToken] = useState<UserToken | null>(null);
 
+  useEffect(() => {
+    const token = sessionStorage.getItem('userToken');
+    setUserToken(() => token);
+    if (userToken) {
+      decodedUserToken();
+    }
+  }, [userToken]);
+
+  // * 토큰 디코드
   const decodedUserToken = () => {
     if (!userToken) return null;
 
     const decodedToken = decodeJWT(userToken);
-    return decodedToken;
+    setUserDecodedToken(() => decodedToken);
   };
 
+  // * 토큰 설정
   const setToken = (token: string) => {
     sessionStorage.setItem('userToken', token);
     setUserToken(token);
   };
 
+  // * 토큰 삭제
   const removeToken = () => {
     sessionStorage.removeItem('userToken');
     setUserToken(null);
@@ -30,5 +43,5 @@ export function useAuth() {
     return decodedToken && decodedToken.exp > Date.now() / 1_000;
   };
 
-  return { decodedUserToken, userToken, setToken, removeToken, isValidToken };
+  return { userDecodedToken, userToken, setToken, removeToken, isValidToken };
 }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,47 +1,29 @@
-import { useEffect, useState } from 'react';
-import { UserToken } from 'types/userTokenTypes';
+import { useState } from 'react';
 
 import decodeJWT from 'utils/decodeJWT';
 
 export function useAuth() {
   const [userToken, setUserToken] = useState<string | null>(null);
-  const [userDecodedToken, setUserDecodedToken] = useState<UserToken | null>(null);
-
-  useEffect(() => {
-    const token = sessionStorage.getItem('userToken');
-    setUserToken(() => token);
-    if (userToken) {
-      decodedUserToken();
-    }
-  }, [userToken]);
-
-  // * 토큰 디코드
-  const decodedUserToken = () => {
-    if (!userToken) return null;
-
-    const decodedToken = decodeJWT(userToken);
-    setUserDecodedToken(() => decodedToken);
-  };
 
   // * 토큰 설정
-  const setToken = (token: string) => {
+  const initSessionStorageUserToken = (token: string) => {
     sessionStorage.setItem('userToken', token);
     setUserToken(token);
   };
 
   // * 토큰 삭제
-  const removeToken = () => {
+  const removeSessionStorageUserToken = () => {
     sessionStorage.removeItem('userToken');
     setUserToken(null);
   };
 
   // * 토큰 만료 확인
-  const isValidToken = () => {
+  const isTokenExpired = () => {
     if (!userToken) return false;
 
     const decodedToken = decodeJWT(userToken);
     return decodedToken && decodedToken.exp > Date.now() / 1_000;
   };
 
-  return { userDecodedToken, userToken, setToken, removeToken, isValidToken };
+  return { userToken, initSessionStorageUserToken, removeSessionStorageUserToken, isTokenExpired };
 }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -9,9 +9,14 @@ import { Google, Naver, Kakao } from 'assets/login/symbols';
 import Logo from 'assets/Logo.svg';
 
 import { post } from 'utils';
+import { useUser } from 'context/UserContext';
+import { useAuth } from 'hooks/useAuth';
 
 export default function Login() {
   const navigate = useNavigate();
+
+  const { initSessionStorageUserToken } = useAuth();
+  const { setToken } = useUser();
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -42,7 +47,9 @@ export default function Login() {
       const res = await post(payload);
 
       if (res.status === 200) {
-        sessionStorage.setItem('userToken', res.data.data.accessToken);
+        const accessToken = res.data.data.accessToken;
+        initSessionStorageUserToken(accessToken);
+        setToken(accessToken);
         alert('로그인 성공!');
         navigate('/');
       }

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,27 +1,38 @@
 import { FiSettings as SettingIcon } from 'react-icons/fi';
 import { AiOutlineQuestionCircle as QuestionIcon } from 'react-icons/ai';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { useAuth } from 'hooks/useAuth';
-
+import Modal from 'components/common/Modal';
 import { Button } from 'components';
 
 import { Tier, myPageList, MypageListItem } from 'constants/myPageList';
-import Modal from 'components/common/Modal';
+import { get } from 'utils';
+
+import { usePet } from 'context/PetContext';
 
 const TEMP_IMAGE_URL =
   'https://blog.kakaocdn.net/dn/GHYFr/btrsSwcSDQV/UQZxkayGyAXrPACyf0MaV1/img.jpg';
 
 export default function MyPage() {
-  const [showModal, setShowModal] = useState(false);
-
-  const { decodedUserToken } = useAuth();
-  const loggedInUser = decodedUserToken();
-  console.log(loggedInUser);
+  const { setHasPet } = usePet();
 
   const navigate = useNavigate();
+
+  const [showModal, setShowModal] = useState(false);
+
+  const [user, setUser] = useState({
+    nickname: '',
+    imagePath: null,
+    hasPet: false,
+  });
+
+  useEffect(() => {
+    if (user.hasPet) {
+      setHasPet(user.hasPet);
+    }
+  });
 
   const onClickQuestionIcon = () => {
     setShowModal(true);
@@ -32,24 +43,35 @@ export default function MyPage() {
   };
 
   const onClickMyPetInfo = () => {
-    //TODO: 펫 등록 여부를 확인할 필요가 있을듯함.
     // 펫 등록된 유저:  /mypage/pets
     // 미등록 유저 : /profile/pets
-    navigate('/profile/pets');
+    if (user.hasPet) return navigate('/mypage/pets');
+    return navigate('/profile/pets');
   };
+
+  useEffect(() => {
+    get({ endpoint: 'users/me' }).then((res) => {
+      setUser(res.data.data);
+    });
+  }, []);
+
+  console.log(user);
 
   return (
     <>
       <div className='container'>
         <section className='profile'>
-          <img className='profile-image' src={TEMP_IMAGE_URL} alt='프로필 이미지' />
+          <img
+            className='profile-image'
+            src={user.imagePath ? user.imagePath : TEMP_IMAGE_URL}
+            alt='프로필 이미지'
+          />
           <div className='setting' onClick={onClickSetting}>
             <ProfileSettingButton />
           </div>
-          <h3 className='nickname'>닉네임</h3>
+          <h3 className='nickname'>{user.nickname}</h3>
           <Button onClick={onClickMyPetInfo} outline width='200px' height='35px'>
-            내 펫 정보
-            {/* //TODO: 펫 등록/미등록에 따라 라우팅 변경 */}
+            {user.hasPet ? '내 펫 정보' : '내 펫 등록'}
           </Button>
         </section>
         <hr className='dividing-line' />

--- a/src/pages/PetProfile/index.tsx
+++ b/src/pages/PetProfile/index.tsx
@@ -1,44 +1,80 @@
 import { Button, Checkbox, FooterButton, InputBox, InputTitle, TextArea } from 'components';
 
+import { useUser } from 'context/UserContext';
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { get } from 'utils';
+
 const TEMP_IMAGE_URL =
   'https://blog.kakaocdn.net/dn/GHYFr/btrsSwcSDQV/UQZxkayGyAXrPACyf0MaV1/img.jpg';
 
+interface MyPet {
+  name: string;
+  age: number;
+  breed: string;
+  isNeutered: boolean;
+  weight: number;
+  gender: boolean;
+  note?: string;
+  imagePath: string;
+}
+
 export default function PetProfile() {
+  const [myPet, setMyPet] = useState<MyPet>();
+
+  const { decodedToken } = useUser();
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    get({
+      endpoint: 'users/pets/detail',
+    }).then((res) => setMyPet(res.data.data));
+  }, []);
+
+  const onClickModification = () => {
+    navigate(`/profile/pets/${decodedToken?.id}`);
+  };
+
   return (
     <>
       <div className='container pet-profile-container'>
-        <img className='profile-img' src={TEMP_IMAGE_URL} alt='프로필 사진' />
+        <img
+          className='profile-img'
+          src={myPet?.imagePath ? myPet.imagePath : TEMP_IMAGE_URL}
+          alt='프로필 사진'
+        />
         <div className='pet-info-inputs'>
           <InputTitle>이름</InputTitle>
-          <InputBox readonly width='250px' placeholder='유토' />
+          <InputBox readonly width='250px' placeholder={myPet?.name} />
 
           <InputTitle>품종</InputTitle>
-          <InputBox readonly width='250px' placeholder='알래스칸 말라뮤트' />
+          <InputBox readonly width='250px' placeholder={myPet?.breed} />
 
           <InputTitle>나이</InputTitle>
-          <InputBox readonly width='250px' placeholder='1살' />
+          <InputBox readonly width='250px' placeholder={`${myPet?.age}살`} />
 
           <InputTitle>성별</InputTitle>
           <div className='gender-buttons'>
-            {/* //TODO: 선택한 성별 하나만 컬러 변경 */}
-            <Button disabled width='120px' outline>
+            <Button disabled width='120px' outline deactivationStyle={!myPet?.gender}>
               암컷
             </Button>
-            <Button disabled width='120px' outline deactivationStyle>
+            <Button disabled width='120px' outline deactivationStyle={!!myPet?.gender}>
               수컷
             </Button>
           </div>
-          <Checkbox readonly text={'중성화 수술을 했어요.'} />
-          {/* //TODO: 중성화 여부에 따라 체크박스 표시 */}
+          <Checkbox checked={myPet?.isNeutered} readonly text={'중성화 수술을 했어요.'} />
 
           <InputTitle>체중</InputTitle>
-          <InputBox readonly width='250px' placeholder='70 kg' />
+          <InputBox readonly width='250px' placeholder={`${myPet?.weight} kg`} />
 
           <InputTitle>특이사항</InputTitle>
-          <TextArea readonly placeholder='' />
+          <TextArea readonly placeholder={`${myPet?.note}`} />
         </div>
       </div>
-      <FooterButton>수정하기</FooterButton>
+      <FooterButton onClick={onClickModification}>수정하기</FooterButton>
     </>
   );
 }

--- a/src/pages/PetProfileEditor/index.tsx
+++ b/src/pages/PetProfileEditor/index.tsx
@@ -13,9 +13,9 @@ import {
 } from 'components';
 
 import checkExtensions from 'utils/checkExtensions';
-import { post } from 'utils';
 
 import { MyPetFormRefs, Profile, RequiredValues } from 'types/petProfileTypes';
+import { postImg } from 'utils/axiosHelper';
 
 const REQUIRED_KEY: RequiredValues[] = ['name', 'breed', 'age', 'gender', 'weight'];
 
@@ -103,23 +103,28 @@ export default function PetProfileEditor() {
     setEmptyValues(() => [...emptyValues] as RequiredValues[]);
     setInputsToShake(() => []);
 
+    const convertProfileData = {
+      ...petProfile,
+      age: Number(petProfile.age),
+      weight: Number(petProfile.weight),
+      gender: petProfile.gender === '암컷' ? true : false,
+    };
+
     const formData = new FormData();
     if (imgFile) {
       formData.append('file', imgFile);
     }
 
+    formData.append(
+      'request',
+      new Blob([JSON.stringify(convertProfileData)], { type: 'application/json' })
+    );
+
     if (!emptyValues.length) {
       try {
-        const res = await post({
+        const res = await postImg({
           endpoint: 'users/pets',
-          body: {
-            request: {
-              ...petProfile,
-              age: Number(petProfile.age),
-              weight: Number(petProfile.weight),
-            },
-            file: formData,
-          },
+          body: formData,
         });
         console.log(res);
 
@@ -244,7 +249,11 @@ export default function PetProfileEditor() {
             </div>
           </div>
 
-          <Checkbox onClick={onClickNeutered} text={'중성화 수술을 했어요.'} />
+          <Checkbox
+            checked={petProfile.isNeutered}
+            onClick={onClickNeutered}
+            text={'중성화 수술을 했어요.'}
+          />
 
           <div className={`${inputsToShake.includes('weight') ? 'shake' : ''}`}>
             <InputTitle isRequire>체중</InputTitle>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,6 +27,7 @@ const MEMBER_ONLY_PAGES = ['mypage', 'profile', 'expert', 'detail', 'newpost'];
 
 export default function Router() {
   const isLoggedIn = sessionStorage.getItem('userToken');
+  // TODO: 로그인에 따른 페이지 라우트 수정 필요
   const location = useLocation();
 
   useEffect(() => {
@@ -75,6 +76,7 @@ export default function Router() {
         {/* 프로필 작성 */}
         {/* //TODO 전문가 프로필 작성 페이지는 전문가 회원 유형만 접근할 수 있도록 추가 필요 */}
         <Route path='profile/pets' element={<PetProfileEditor />} />
+        <Route path='profile/pets/:id' element={<PetProfileEditor />} />
         <Route path='profile/experts' element={<ExpertProfileEditor />} />
 
         {/* 프로필 보기 */}

--- a/src/styles/pages/_my-profile-editor.scss
+++ b/src/styles/pages/_my-profile-editor.scss
@@ -9,7 +9,7 @@
   .nickname {
     display: flex;
     align-items: center;
-    gap: 15px;
+    gap: 0.8rem;
   }
 
   .nickname strong {

--- a/src/types/petProfileTypes.ts
+++ b/src/types/petProfileTypes.ts
@@ -1,10 +1,10 @@
 export interface Profile {
   name: string;
   breed: string;
-  age: string;
+  age: number;
   gender: string;
   isNeutered: boolean;
-  weight: string;
+  weight: number;
   note?: string;
 }
 

--- a/src/utils/axiosHelper.ts
+++ b/src/utils/axiosHelper.ts
@@ -44,6 +44,15 @@ export async function post({ endpoint, body }: POST) {
   });
 }
 
+export async function postImg({ endpoint, body }: POST) {
+  return axios.post(`${SERVER_URL}${endpoint}`, body, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      Authorization: sessionStorage.getItem('userToken'),
+    },
+  });
+}
+
 export async function patch({ endpoint, body }: PATCH) {
   return axios.patch(`${SERVER_URL}${endpoint}`, body, {
     headers: {

--- a/src/utils/initialValues/myProfileEditor.ts
+++ b/src/utils/initialValues/myProfileEditor.ts
@@ -1,0 +1,5 @@
+export const warningMessage = {
+  nickname: '2~10자 영어, 한글, 숫자만 사용할 수 있어요.',
+  startsWithPuddy: '퍼디로 시작하는 닉네임은 사용할 수 없어요.',
+  used: '이미 사용중인 닉네임이에요.',
+};

--- a/src/utils/validate/checkNickname.ts
+++ b/src/utils/validate/checkNickname.ts
@@ -1,4 +1,4 @@
-const NICKNAME_REG_EXP = /^[가-힣a-zA-Z0-9]{2,10}$/;
+const NICKNAME_REG_EXP = /^(?!퍼디)[가-힣a-zA-Z0-9]{2,10}$/;
 
 export function isValidNickname(nickname: string) {
   return NICKNAME_REG_EXP.test(nickname);


### PR DESCRIPTION
에러와 3일 동안 싸우느라 풀리퀘가 늦어졌네요.. ㅠ.ㅠ
우선 함께 공유해야 하는 부분 중 큰 변경사항은 다음과 같습니다.

### 1. user context 추가
디코드 토큰을 전역에서 사용할 수 있도록 useAuth에서 import 후 호출하는 방식에서 context로 변경하였습니다. 따라서 디코드 토큰이 필요한 페이지의 경우 다음과 같이 호출하여 사용하시면 됩니다.

`import { useUser } from 'context/UserContext';`
`const { decodedToken } = useUser();`

`decodedToken.nickname` 같은 형태로 사용하실 수 있어요.

**따라서, 이전에 useAuth 를 호출해서 사용하고 계시다면 해당 부분은 제거해주세요!**
 나중에 리프레시 토큰을 사용하는 부분을 추가하면 사용해야 할 수도 있을 것 같아 useAuth는 우선 놔두긴 했지만 아직 사용은 하지 말아주세요!

### 2. axios 헬퍼 함수 수정
- axios의 instance 생성 후 interceptors를 통해 중복되는 코드가 반복적으로 작성되는 부분을 개선했습니다.
- 그 외 post, patch 함수에서는 컨텐트 타입을 분기해야 하므로 `is~`로 시작하는 파라미터 값을 추가했습니다. 
- 이전에 postImg 함수를 사용하고 계시다면 해당 코드 부분은 수정이 필요합니다. 
post, patch 함수도 is~ 파라미터가 추가되었기 때문에 마찬가지로 코드 수정이 필요할 수 있어요.
- 일부 코드는 메인 브랜치에서 테스트를 해봐야 할 것 같은데, 혹시라도 사용 중 에러가 있다면 고쳐서 사용하셔도 됩니당!..!

### 그 외
#4 #21 #32 번 페이지와 관련되어 서버 통신 코드를 추가했습니다.

## 이슈 공유
토큰 사용과 관련한 문제가 발생하여 해당 내용을 기록하였습니다.
이슈 내용이 많아 아래 링크로 대체합니다.
https://reasonz.tistory.com/52
