### PR TITLE
[FEAT] 전문가 프로필 등록, 전문가 프로필 보기 페이지

### DIFF
--- a/src/constants/myPageList.ts
+++ b/src/constants/myPageList.ts
@@ -3,11 +3,17 @@ export enum Tier {
   CONTENT_NAME,
 }
 
+export enum Role {
+  USER = 'ROLE_USER',
+  EXPERT = 'ROLE_EXPERTS',
+}
+
 export interface MypageListItem {
   tier: Tier;
   title: string;
   url?: string;
   icon?: boolean;
+  role?: Role;
 }
 
 export const myPageList: Array<MypageListItem> = [
@@ -34,6 +40,13 @@ export const myPageList: Array<MypageListItem> = [
     title: '전문가 인증하기',
     url: '/mypage/experts',
     icon: true,
+    role: Role.USER,
+  },
+  {
+    tier: Tier.CONTENT_NAME,
+    title: '전문가 프로필 등록',
+    url: '/profile/experts',
+    role: Role.EXPERT,
   },
   {
     tier: Tier.TITLE,

--- a/src/context/PetContext.tsx
+++ b/src/context/PetContext.tsx
@@ -20,13 +20,18 @@ export const PetProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   useEffect(() => {
-    get({ endpoint: '/users/pets/detail' }).then((res) => {
-      //TODO: 펫 등록 여부를 확인할 수 없어서 임시 사용중
-      console.log('pet context', hasPet);
-      if (res.data.data.age) {
-        setHasPet(() => true);
-      }
-    });
+    get({ endpoint: '/users/pets/detail' })
+      .then((res) => {
+        //TODO: 펫 등록 여부를 확인할 수 없어서 임시 사용중
+        // ! 펫 정보 없으면 500 에러 날 거예요
+        console.log('pet context', hasPet);
+        if (res.data.data.age) {
+          setHasPet(() => true);
+        }
+      })
+      .catch((err) => {
+        console.log(err, 'PetContext에서 에러 발생.');
+      });
   }, [hasPet]);
 
   return <PetContext.Provider value={contextValue}>{children}</PetContext.Provider>;

--- a/src/pages/ExpertProfile/index.tsx
+++ b/src/pages/ExpertProfile/index.tsx
@@ -2,7 +2,7 @@ import { useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { HiOutlineStar as OutlineStar, HiStar as Star } from 'react-icons/hi';
 
-import { Button } from 'components';
+import { Button, CustomHeader } from 'components';
 
 import { get } from 'utils/axiosHelper';
 
@@ -32,6 +32,7 @@ export default function ExpertProfile() {
 
   return (
     <>
+      <CustomHeader title={`${profile?.username ? profile.username : ''} 전문가 프로필`} />
       <div className='expert-profile-container'>
         <section className='profile expert'>
           <img className='profile-image' src={TEMP_IMAGE_URL} alt='프로필 이미지' />

--- a/src/pages/ExpertProfile/index.tsx
+++ b/src/pages/ExpertProfile/index.tsx
@@ -1,41 +1,68 @@
+import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { HiOutlineStar as OutlineStar, HiStar as Star } from 'react-icons/hi';
+
 import { Button } from 'components';
+
+import { get } from 'utils/axiosHelper';
+
+import { Profile } from 'types/expertProfileTypes';
 
 const TEMP_IMAGE_URL =
   'https://blog.kakaocdn.net/dn/GHYFr/btrsSwcSDQV/UQZxkayGyAXrPACyf0MaV1/img.jpg';
 
 export default function ExpertProfile() {
+  const location = useLocation();
+  const expertId = location.pathname.split('/').pop();
+  const [profile, setProfile] = useState<Profile>();
+
+  // ! 회원 id를 가지고 전문가를 선별하고 있어서 존재하지 않는 전문가 페이지 진입이 가능함
+  useEffect(() => {
+    if (!expertId) return;
+    get({ endpoint: `experts/${expertId}` })
+      .then((res) => {
+        setProfile(res.data.data);
+      })
+      .catch((err) => {
+        console.error(err.resultCode);
+      });
+  }, [expertId]);
+
+  console.log(profile?.careerList);
+
   return (
     <>
       <div className='expert-profile-container'>
         <section className='profile expert'>
           <img className='profile-image' src={TEMP_IMAGE_URL} alt='프로필 이미지' />
           <div className='profile-expert_header'>
-            <h3 className='profile-expert_name'>김철수</h3>
+            <h3 className='profile-expert_name'>{profile?.username}</h3>
             <OutlineStar className='outline-star' />
             {/* //TODO: 별 아이콘 클릭 시 색상 채우기 */}
           </div>
-          <h4 className='profile-expert_education'>서울대학교 수의학</h4>
+          <h4 className='profile-expert_education'>{profile?.education}</h4>
         </section>
         <hr className='dividing-line' />
         <div className='profile-expert-contents-container'>
           <div className='content'>
             <h5>경력 사항</h5>
             <ul className='profile-expert_educations'>
-              <li className='profile-expert_content'>서울대학교 수의과대학 졸업</li>
-              <li className='profile-expert_content'>서울대학교 수의과대학 임상 로테이션 수료</li>
+              {profile?.careerList && profile?.careerList.length > 0 && (
+                <>
+                  {profile?.careerList.map((career) => {
+                    return <li className='profile-expert_content'>{career}</li>;
+                  })}
+                </>
+              )}
             </ul>
           </div>
           <div className='content'>
             <h5>소개</h5>
-            <p className='profile-expert_content produce'>
-              서울 K동물병원에서 부원장으로 근무하고 있습니다. 우리 아이와 만남부터 이별까지, 사람과
-              동물의 동행이 아름다울 수 있도록 든든한 주치의가 되고 싶습니다.
-            </p>
+            <p className='profile-expert_content produce'>{profile?.introduce}</p>
           </div>
           <div className='content'>
             <h5>근무지/매장 위치</h5>
-            <p className='profile-expert_content'>서울특별시 금천구 시흥대로 251 산호시티빌</p>
+            <p className='profile-expert_content'>{profile?.location}</p>
           </div>
         </div>
         <Button secondStyle outline>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -7,16 +7,19 @@ import { Link, useNavigate } from 'react-router-dom';
 import Modal from 'components/common/Modal';
 import { Button } from 'components';
 
-import { Tier, myPageList, MypageListItem } from 'constants/myPageList';
+import { Tier, myPageList, MypageListItem, Role } from 'constants/myPageList';
 import { get } from 'utils';
 
 import { usePet } from 'context/PetContext';
+import { useUser } from 'context/UserContext';
 
 const TEMP_IMAGE_URL =
   'https://blog.kakaocdn.net/dn/GHYFr/btrsSwcSDQV/UQZxkayGyAXrPACyf0MaV1/img.jpg';
 
 export default function MyPage() {
   const { hasPet, setHasPet } = usePet();
+  const { decodedToken } = useUser();
+  const [role, setRole] = useState('ROLE_EXPERT');
 
   const navigate = useNavigate();
 
@@ -71,7 +74,7 @@ export default function MyPage() {
         </section>
         <hr className='dividing-line' />
         <section className='setting-menus'>
-          <ul>{MenuItems(myPageList, onClickQuestionIcon)}</ul>
+          <ul>{createMenuItems({ list: myPageList, role, onClick: onClickQuestionIcon })}</ul>
         </section>
         {showModal && (
           <Modal closeModal={() => setShowModal(false)}>
@@ -98,9 +101,25 @@ const ProfileSettingButton = () => {
   );
 };
 
-const MenuItems = (list: Array<MypageListItem>, onClick: () => void) => {
+export interface MenuProps {
+  role: string;
+  list: Array<MypageListItem>;
+  onClick: () => void;
+}
+
+export const createMenuItems = ({ role, list, onClick }: MenuProps) => {
+  // TODO: 유저 role에 따라 메뉴 다르게 보여주기
+  const onlyUserMenu = list.filter((menu) => {
+    return menu.role === Role.USER;
+  });
+
+  const onlyExpertMenu = list.filter((menu) => {
+    return menu.role === Role.EXPERT;
+  });
+
   return list.map((item, i) => {
     const isTitle = item.tier === Tier.TITLE;
+    const isExpert = item.role === Role.EXPERT;
 
     return (
       <li key={`${item.title} ${i}`} role='button'>

--- a/src/styles/layout/header/_left-header.scss
+++ b/src/styles/layout/header/_left-header.scss
@@ -7,7 +7,6 @@
 
 .custom-header-left {
   font-size: 2rem;
-  width: 100%;
   padding-left: 5vw;
 
   .prev {

--- a/src/styles/layout/header/_right-header.scss
+++ b/src/styles/layout/header/_right-header.scss
@@ -9,7 +9,6 @@
 .custom-header-right {
   color: $icon-color;
   text-align: right;
-  width: 100%;
   padding-right: 5vw;
   margin-top: 2px;
 }

--- a/src/styles/pages/_expert-profile.scss
+++ b/src/styles/pages/_expert-profile.scss
@@ -17,6 +17,8 @@
 
 .expert + .dividing-line {
   width: 100%;
+  margin-top: 20px;
+  margin-bottom: 30px;
 }
 
 .profile-expert_header {
@@ -43,7 +45,7 @@
 .profile-expert_education {
   font-size: 1.4rem;
   color: $color-gray02;
-  margin-top: 7px;
+  margin-top: 10px;
 }
 
 /* 전문가 프로필 하단: 경력사항 등*/
@@ -59,8 +61,13 @@
   }
 
   .content {
-    font-size: 1.2rem;
+    font-size: 1.3rem;
+    line-height: 2rem;
     margin-bottom: 2rem;
+  }
+
+  .produce {
+    line-height: 2.3rem;
   }
 }
 

--- a/src/types/expertProfileTypes.ts
+++ b/src/types/expertProfileTypes.ts
@@ -1,0 +1,7 @@
+export interface Profile {
+  username: string;
+  education: string;
+  careerList?: string[];
+  introduce?: string;
+  location?: string;
+}


### PR DESCRIPTION
#8  #7 

**이전에 슬랙에서 전달드렸던 `일부 이슈가 포함`되어 있습니다.**

- 우선, 서류 제출 관련 로직이 구현되어있지 않아서
현재는 일반 유저가 서류 제출 버튼을 누르면 전문가 권한을 부여받을 수 있습니다. 
- 강제 로그아웃 후 로그인 페이지로 라우팅되는데 재로그인 하면 전문가 권한으로 토큰이 발급됩니다. 
- 전문가 권한을 가진 유저는 전문가 프로필 등록 페이지 접근이 가능합니다.

- 프로필 등록 후 라우팅은 아직 처리하지 않았는데
이건 서버에서 수정하기 API를 뚫어주시면 추가할 예정이에요.

- 전문가 프로필 이미지도 서버에서 보내주시면 반영할 예정입니다.

![Honeycam 2023-04-10 16-04-01](https://user-images.githubusercontent.com/48672106/230846561-6e3b849f-59f1-4c8b-9376-306b7646d2e1.gif)



<br/>
<br/>

- 마찬가지로 아래 페이지에도 전달드렸던 이슈가 포함되어 있습니다.
- 당장은 진입 가능한 경로가 없어서 url 입력을 통해 수동으로 진입했습니다.
- 회원으로 등록되어있는 id 값을 기준으로 서버에서 해당 페이지의 데이터를 보내주기 때문에 전문가가 아닌 유저의 id 번호를 입력해도 접속이 가능합니다. 
- 즉, 전문가 유무에 상관없이 전문가 프로필 보기 페이지가 `존재는` 합니다.

![Honeycam 2023-04-10 15-57-27](https://user-images.githubusercontent.com/48672106/230845834-f37b5e15-a5bc-48a5-a0e5-f87367573c84.gif)

