### PR TITLE
[FEAT] 소셜 로그인, 전문가 프로필 수정하기, 비밀번호 변경, 아이디/비밀번호 찾기 페이지 추가

### DIFF
--- a/src/components/common/ButtonModal.tsx
+++ b/src/components/common/ButtonModal.tsx
@@ -2,16 +2,18 @@ import Button from './Button';
 import Modal from './Modal';
 
 interface ButtonModalProps {
-  text: string;
-  subText: string;
+  text?: string;
+  subText?: string;
   cancleText: string;
   confirmText: string;
+  children?: React.ReactNode;
   closeModal: () => void;
   onCancle: () => void; // 왼쪽 버튼
   onConfirm: () => void; // 오른쪽 버튼
 }
 
 export default function ButtonModal({
+  children,
   text,
   subText,
   cancleText,
@@ -25,6 +27,7 @@ export default function ButtonModal({
       <div className='button-modal-container'>
         <h3 className='title-text'>{text}</h3>
         <p className='sub-text'>{subText}</p>
+        {children}
         <div className='btn-container'>
           <Button onClick={onCancle} width='120px' outline>
             {cancleText}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,11 +1,12 @@
 import { createPortal } from 'react-dom';
 
 interface ModalProps {
+  className?: string;
   children: React.ReactNode;
   closeModal: () => void;
 }
 
-export default function Modal({ children, closeModal }: ModalProps) {
+export default function Modal({ children, closeModal, className }: ModalProps) {
   const onClickModalBox = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
   };
@@ -13,7 +14,7 @@ export default function Modal({ children, closeModal }: ModalProps) {
   return createPortal(
     <div className='modal-bg' onClick={closeModal}>
       <div className='modal-container'>
-        <div className='modal-box' onClick={onClickModalBox}>
+        <div className={`modal-box ${className}`} onClick={onClickModalBox}>
           {children}
         </div>
       </div>

--- a/src/components/signup/InputField.tsx
+++ b/src/components/signup/InputField.tsx
@@ -1,4 +1,5 @@
 import { InputBox, InputTitle, Message } from 'components';
+import { ChangeAccountInterface } from 'pages/MyPage/ChangePassword';
 
 import { FieldName, Membership } from 'types/signupTypes';
 
@@ -9,7 +10,7 @@ interface InputFieldProps {
   placeholder: string;
   target: FieldName;
   title: string;
-  registrationMembership: Membership;
+  registrationMembership: Membership | ChangeAccountInterface;
   initWarningMessage: Membership;
   warningMessage: Membership;
   showCorrectMessage?: { account: boolean; email: boolean };

--- a/src/constants/apiEndpoint.ts
+++ b/src/constants/apiEndpoint.ts
@@ -81,8 +81,14 @@ export const answersApi = Object.freeze({
 */
 const EXPERT_API = 'experts';
 export const expertApi = Object.freeze({
+  /* 전문가 프로필 GET, PUT */
   GET_PUT_EXPERT: `${EXPERT_API}`,
+
+  /* 전문가 프로필 POST */
   POST_EXPERT: `users/${EXPERT_API}`,
+
+  /* 전문가 서류 제출 */
+  POST_EXPERT_DOCS: `${EXPERT_API}/send-docs`,
 
   /* 전문가 프로필 조회 시 */
   requestExpertId: (userId: string) => {

--- a/src/constants/apiEndpoint.ts
+++ b/src/constants/apiEndpoint.ts
@@ -209,9 +209,13 @@ export const myPageApi = Object.freeze({
 
   /* 유저 권한 변경 */
   PATCH_USER_AUTH: `${MY_PAGE_API}/update-auth`,
+
   GET_MY_POSTS: `${MY_PAGE_API}/posts`,
   GET_MY_PAGE_INFO: `${MY_PAGE_API}/me`,
   DELETE_LOGOUT: `${MY_PAGE_API}/logout`,
+
+  /* 비밀번호 변경 */
+  PATCH_MY_PASSWORD: `${MY_PAGE_API}/change-password`,
 });
 
 /* ------------------------------------- */

--- a/src/constants/apiEndpoint.ts
+++ b/src/constants/apiEndpoint.ts
@@ -181,6 +181,7 @@ export const loginApi = Object.freeze({
 */
 const SOCIAL_LOGIN_API = 'oauth';
 export const socialLoginApi = Object.freeze({
+  POST_SOCIAL_JOIN_KAKAO: `${SOCIAL_LOGIN_API}/join`,
   POST_SOCIAL_LOGIN_KAKAO: `${SOCIAL_LOGIN_API}/kakao`,
 });
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -84,6 +84,11 @@ export const MY_PAGE_AUTH_EXPERT_PATH = '/mypage/experts';
 /* 마이페이지 전문가 프로필 작성 */
 export const EXPERTS_PROFILE_PATH = '/profile/experts';
 
+/* 전문가 프로필 수정 */
+export const getPathModificationExpertProfile = (userId: string = ':id') => {
+  return `/profile/experts/${userId}`;
+};
+
 /* 마이페이지 설정 - 계정 */
 export const MY_PAGE_ACCOUNT_PATH = '/mypage/account';
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -95,6 +95,9 @@ export const getPathModificationExpertProfile = (userId: string = ':id') => {
 /* 마이페이지 설정 - 계정 */
 export const MY_PAGE_ACCOUNT_PATH = '/mypage/account';
 
+/* 마이페이지 설정 - 비밀번호 변경 */
+export const MY_PAGE_CHANGE_PW = '/users/password';
+
 /* 마이페이지 설정 - 회원탈퇴 */
 export const MY_PAGE_WITHDRAWAL_PATH = '/mypage/withdrawal';
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -64,6 +64,9 @@ export const MY_PAGE_PATH = '/mypage';
 /* 마이페이지 내가 쓴 게시글/댓글 */
 export const MY_POSTS_PATH = 'mypage/posts';
 
+/* 마이페이지 즐겨찾기 */
+export const BOOKMARK = 'mypage/bookmarks';
+
 /* 마이페이지 내 프로필 수정 */
 export const MY_PAGE_PROFILE_PATH = '/mypage/profile';
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -56,6 +56,15 @@ export const KAKAO_AUTH_PATH = '/oauth/authorize';
 /* 회원가입 페이지 */
 export const JOIN_PATH = '/auth/Signup';
 
+/* 아이디/비밀번호 찾기 */
+export const FIND_ID_PW_PATH = '/account/recovery';
+
+/* 아이디 찾기 */
+export const FIND_ID_PATH = '/account/recovery/id';
+
+/* 비밀번호 찾기 */
+export const FIND_PW_PATH = '/account/recovery/password';
+
 /* =========================================================== */
 
 /* 마이페이지 */

--- a/src/constants/token.ts
+++ b/src/constants/token.ts
@@ -1,0 +1,1 @@
+export const TOKEN_KEY = 'userToken';

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { UserToken } from 'types/userTokenTypes';
+import { TOKEN_KEY } from 'constants/token';
+
 import decodeJWT from 'utils/decodeJWT';
 
 interface UserContextProps {
@@ -16,8 +18,6 @@ export const UserContext = createContext<UserContextProps>({
   setToken: () => {},
   setDecodedToken: () => {},
 });
-
-const TOKEN_KEY = 'userToken';
 
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const [token, setToken] = useState<string | null>(null);

--- a/src/pages/AuthExpert/index.tsx
+++ b/src/pages/AuthExpert/index.tsx
@@ -9,9 +9,11 @@ import { patch } from 'utils';
 import { useUser } from 'context/UserContext';
 import { myPageApi } from 'constants/apiEndpoint';
 import { LOGIN_PATH } from 'constants/routes';
+import Modal from 'components/common/Modal';
 
 export default function AuthExpert() {
   const navigate = useNavigate();
+  const [showModal, setShowModal] = useState(false);
 
   const { decodedToken } = useUser();
   const auth = decodedToken?.auth;
@@ -52,9 +54,8 @@ export default function AuthExpert() {
       const res = await patch({ endpoint: `${myPageApi.PATCH_USER_AUTH}`, isFormData: false });
       console.log(res);
       if (res.status === 201) {
-        window.alert('전문가 권한 부여 완료. 재로그인 해주세요.');
+        setShowModal(true);
         sessionStorage.removeItem('userToken');
-        navigate(`${LOGIN_PATH}`);
       }
     } catch (err) {
       console.error(err);
@@ -85,26 +86,42 @@ export default function AuthExpert() {
   };
 
   return (
-    <div className='auth-expert-container'>
-      <CustomHeader title='전문가 인증' hideIcon />
-      <h3 className='auth-expert-title'>
-        <strong>자격증 및 기타 인증 서류</strong>를 업로드해 주세요.
-        <br />
-        제출된 서류는 검토 후 <strong>메일을 통해 안내</strong>해 드려요.
-      </h3>
-      <label className='file-input'>
-        <FileInput
-          text={fileUploaderText}
-          onChange={onChangeFile}
-          accept='.pdf, .doc, .docx, .hwp, .jpg, .jpeg, .png'
-          placeholder='파일 첨부'
+    <>
+      {showModal && (
+        <Modal
+          children={
+            <>
+              <h2 className='modal-title'>전문가 권한 부여 완료</h2>
+              <div className='modal-content'>다시 로그인 해주세요. 😊</div>
+            </>
+          }
+          closeModal={() => {
+            setShowModal(false);
+            navigate(`${LOGIN_PATH}`);
+          }}
         />
-      </label>
-      <div className='auth-expert-allowed'>
-        <p>허용 확장자 : .pdf, .doc, .docx, .hwp, .jpg, .jpeg, .png</p>
-        <p>최대 10MB</p>
+      )}
+      <div className='auth-expert-container'>
+        <CustomHeader title='전문가 인증' hideIcon />
+        <h3 className='auth-expert-title'>
+          <strong>자격증 및 기타 인증 서류</strong>를 업로드해 주세요.
+          <br />
+          제출된 서류는 검토 후 <strong>메일을 통해 안내</strong>해 드려요.
+        </h3>
+        <label className='file-input'>
+          <FileInput
+            text={fileUploaderText}
+            onChange={onChangeFile}
+            accept='.pdf, .doc, .docx, .hwp, .jpg, .jpeg, .png'
+            placeholder='파일 첨부'
+          />
+        </label>
+        <div className='auth-expert-allowed'>
+          <p>허용 확장자 : .pdf, .doc, .docx, .hwp, .jpg, .jpeg, .png</p>
+          <p>최대 10MB</p>
+        </div>
+        <FooterButton onClick={onClickSubmit}>제출하기</FooterButton>
       </div>
-      <FooterButton onClick={onClickSubmit}>제출하기</FooterButton>
-    </div>
+    </>
   );
 }

--- a/src/pages/Bookmark/index.tsx
+++ b/src/pages/Bookmark/index.tsx
@@ -1,0 +1,3 @@
+export default function Bookmark() {
+  return <h2 style={{ marginTop: '60px', fontSize: '30px' }}>준비중이에요! 🙇‍♂️</h2>;
+}

--- a/src/pages/ExpertProfile/index.tsx
+++ b/src/pages/ExpertProfile/index.tsx
@@ -1,23 +1,36 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { HiOutlineStar as OutlineStar, HiStar as Star } from 'react-icons/hi';
 
-import { Button, CustomHeader } from 'components';
+import { Button, CustomHeader, FooterButton } from 'components';
 
 import { get } from 'utils/axiosHelper';
 
 import { Profile } from 'types/expertProfileTypes';
-import { expertApi } from 'constants/apiEndpoint';
 import { ApiError } from 'types/errorsTypes';
-import { NOT_FOUND_PATH } from 'constants/routes';
+
+import { expertApi } from 'constants/apiEndpoint';
+import { NOT_FOUND_PATH, getPathModificationExpertProfile } from 'constants/routes';
+
+import { useUser } from 'context/UserContext';
 
 const TEMP_IMAGE_URL =
   'https://blog.kakaocdn.net/dn/GHYFr/btrsSwcSDQV/UQZxkayGyAXrPACyf0MaV1/img.jpg';
 
 export default function ExpertProfile() {
   const location = useLocation();
+  const navigate = useNavigate();
   const expertId = location.pathname.split('/').pop();
+
   const [profile, setProfile] = useState<Profile>();
+  const { decodedToken } = useUser();
+
+  /* 현재 전문가 유저가 프로필 작성 여부를 알 수 없으므로 아래 코드 임시 사용중 */
+  const isMyProfile = profile?.expertId === decodedToken?.id;
+
+  const onClickModificationExpertProfile = () => {
+    navigate(`${getPathModificationExpertProfile(decodedToken?.id.toString())}`);
+  };
 
   useEffect(() => {
     if (!expertId) return;
@@ -86,6 +99,9 @@ export default function ExpertProfile() {
           리뷰 보기
         </Button>
       </div>
+      {isMyProfile && (
+        <FooterButton onClick={onClickModificationExpertProfile}>수정하기</FooterButton>
+      )}
     </>
   );
 }

--- a/src/pages/ExpertProfile/index.tsx
+++ b/src/pages/ExpertProfile/index.tsx
@@ -43,7 +43,11 @@ export default function ExpertProfile() {
       <CustomHeader title={`${profile?.username ? profile.username : ''} 전문가 프로필`} />
       <div className='expert-profile-container'>
         <section className='profile expert'>
-          <img className='profile-image' src={TEMP_IMAGE_URL} alt='프로필 이미지' />
+          <img
+            className='profile-image'
+            src={profile?.imagePath || TEMP_IMAGE_URL}
+            alt='프로필 이미지'
+          />
           <div className='profile-expert_header'>
             <h3 className='profile-expert_name'>{profile?.username}</h3>
             <OutlineStar className='outline-star' />

--- a/src/pages/ExpertProfileEditor/index.tsx
+++ b/src/pages/ExpertProfileEditor/index.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useEffect, useRef, ChangeEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Button, CustomHeader, FooterButton, InputBox, TextArea } from 'components';
 import InputTilte from 'components/common/InputTitle';
 
 import { useUser } from 'context/UserContext';
-import { post } from 'utils';
+import { get, post } from 'utils';
+import { put } from 'utils/axiosHelper';
 
 import { Profile } from 'types/expertProfileTypes';
+
 import { expertApi } from 'constants/apiEndpoint';
 import { HOME_PATH, MY_PAGE_PATH } from 'constants/routes';
 
@@ -34,18 +36,108 @@ export default function ExpertProfileEditor() {
 
   const [isDisabled, setIsDisabled] = useState(true);
 
-  // TODO: 이미 프로필을 등록한 전문가 유저는 프로필 보기 페이지로 라우팅 해야할듯
+  const [isModification, setIsModification] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
 
-  const submitExpertProfile = async () => {
-    try {
-      const res = await post({ endpoint: `${expertApi.POST_EXPERT}`, body: profile });
-      if (res.data.resultCode === 'SUCCESS') {
-        alert('프로필 등록 완료');
-        navigate(`${MY_PAGE_PATH}`);
-        // TODO: 전문가 프로필 수정은 ?
+  // TODO: 이미 프로필을 등록한 전문가 유저는 프로필 보기 페이지로 라우팅 해야할듯
+  const { pathname } = useLocation();
+  const expertId = pathname.split('/').pop();
+
+  /*
+   * 서버에서 전문가 유저가 프로필을 등록했는지 알려줘야 함.
+  - 발생할 수 있는 문제
+  1. 프로필을 등록하지 않은 전문가가 URL로 입장했을 때 문제가 있음
+  2. 마이페이지에서 작성유무를 알 방법이 없어서 메뉴를 동적으로 변경할 수 없음.
+
+   * 현재 userID와 path의 id가 같은지 확인한다. 
+   * 같을 경우 수정 페이지로 이동, 다를 경우 404 페이지로 라우트
+   * 
+   * 에디터 페이지 데이터 바인딩, 포커싱
+   * 경력은 최대 5개까지 가능하므로 1개를 초과하여 작성했다면 인풋을 미리 만들어놔야 함
+   * 작성완료 버튼 누르면 서버로 전송 (PUT)
+   * 
+   */
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted && !decodedToken) return;
+
+    if (isModification && expertId !== decodedToken?.id.toString()) {
+      window.alert('404 NOT FOUND'); // TODO: 자기 프로필 수정이 아닌 경우
+      navigate('/');
+    }
+  }, [isModification]);
+
+  useEffect(() => {
+    if (!decodedToken) return;
+
+    if (decodedToken.id.toString() === expertId) setIsModification(true);
+    else setIsModification(false);
+  }, [decodedToken, expertId]);
+
+  useEffect(() => {
+    if (!isMounted || !expertId) return;
+
+    const getModificationExpertProfile = async () => {
+      try {
+        const res = await get({ endpoint: `${expertApi.requestExpertId(expertId)}` });
+        const data = res.data.data;
+        setProfile((prev) => ({
+          ...prev,
+          careerList: data.careerList,
+          education: data.education,
+          imagePath: data.imagePath,
+          introduce: data.introduce,
+          username: data.username,
+        }));
+        setCareerInputs(() => {
+          return Array(data.careerList.length)
+            .fill('')
+            .map((_, i) => {
+              return data.careerList[i];
+            });
+        });
+      } catch (err) {
+        console.error(err);
       }
-    } catch (err) {
-      console.error(err);
+    };
+
+    getModificationExpertProfile();
+  }, [isMounted, expertId]);
+
+  // TODO: 코드 리팩토링
+  const submitExpertProfile = async () => {
+    if (!isModification) {
+      // * 등록하기 * //
+      try {
+        const res = await post({ endpoint: `${expertApi.POST_EXPERT}`, body: profile });
+        if (res.data.resultCode === 'SUCCESS') {
+          alert('프로필 등록 완료');
+          navigate(`${MY_PAGE_PATH}`);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    } else {
+      // * 수정하기 * //
+      try {
+        profile.careerList = profile.careerList?.filter((value) => !!value); // 빈 값 제거
+
+        const res = await put({
+          endpoint: `${expertApi.GET_PUT_EXPERT}`,
+          isFormData: false,
+          body: profile,
+        });
+        if (res.data.resultCode === 'SUCCESS') {
+          window.alert('수정이 완료되었어요.');
+          navigate(-1);
+        }
+      } catch (err) {
+        console.error(err);
+      }
     }
   };
 
@@ -98,6 +190,8 @@ export default function ExpertProfileEditor() {
     } else setIsDisabled(() => true);
   }, [profile]);
 
+  // TODO: 체크해야할 부분 location이 안 넘어 옴
+  // TODO: 이름하고 학력 외에 다른 값 모두 required 인 것 같으니 확인 필요
   useEffect(() => {
     if (inputRef.current) inputRef.current.focus();
   }, [inputRef]);
@@ -114,6 +208,7 @@ export default function ExpertProfileEditor() {
           inputRef={inputRef}
           width='250px'
           required
+          value={isModification ? profile.username : ''}
           placeholder='이름을 입력해주세요.'
         />
 
@@ -123,6 +218,7 @@ export default function ExpertProfileEditor() {
           onChange={onChangeInput('education')}
           width='250px'
           required
+          value={isModification ? profile.education : ''}
           placeholder='최종 학력을 입력해주세요.'
         />
 
@@ -136,7 +232,7 @@ export default function ExpertProfileEditor() {
                 required
                 placeholder='경력을 입력해주세요.'
                 key={`${careerIndex} ${i}`}
-                value={careerInput}
+                value={isModification ? careerInput : ''}
                 onChange={onChangeCareerInput(i)}
               />
             );
@@ -151,6 +247,7 @@ export default function ExpertProfileEditor() {
           maxLength={200}
           onChange={onChangeInput('introduce')}
           placeholder='자유롭게 소개를 작성해주세요.'
+          value={isModification ? profile.introduce : ''}
         ></TextArea>
 
         <InputTilte>근무지/매장 위치</InputTilte>
@@ -159,6 +256,7 @@ export default function ExpertProfileEditor() {
           onChange={onChangeInput('location')}
           width='250px'
           placeholder='근무지 또는 매장 위치를 홍보해보세요.'
+          value={isModification ? profile.location : ''}
         />
         <FooterButton disabled={isDisabled} onClick={submitExpertProfile}>
           작성완료

--- a/src/pages/FindAccount/Id.tsx
+++ b/src/pages/FindAccount/Id.tsx
@@ -1,0 +1,28 @@
+import { CustomHeader, FooterButton, InputBox, Message } from 'components';
+import InputTilte from 'components/common/InputTitle';
+
+export default function Id() {
+  return (
+    <>
+      <CustomHeader title='아이디 찾기' hideIcon />
+      <div className='find-id-container'>
+        <div>
+          <InputTilte isRequire>이름</InputTilte>
+          <InputBox required placeholder='이름을 입력해주세요.' />
+        </div>
+        <div>
+          <InputTilte isRequire>이메일</InputTilte>
+          <InputBox required placeholder='이메일을 입력해주세요.' />
+        </div>
+        <div className='message-result'>
+          {/* <p>해당 정보로 가입된 아이디가 존재해요.</p> */}
+          {/* <p>reas***</p>
+          
+          //TODO: 현재 아이디 찾기 API가 없음
+          */}
+        </div>
+        <FooterButton>확인</FooterButton>
+      </div>
+    </>
+  );
+}

--- a/src/pages/FindAccount/Password.tsx
+++ b/src/pages/FindAccount/Password.tsx
@@ -1,0 +1,90 @@
+import { ChangeEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { CustomHeader, FooterButton, InputBox } from 'components';
+import InputTilte from 'components/common/InputTitle';
+
+import { post } from 'utils';
+
+import { findIdPwApi } from 'constants/apiEndpoint';
+import { LOGIN_PATH } from 'constants/routes';
+
+export default function Password() {
+  const [userInfo, setUserInfo] = useState({
+    username: '',
+    account: '',
+    email: '',
+  });
+
+  const navigate = useNavigate();
+
+  const onClickChangePassword = async () => {
+    // 비밀번호 변경 요청
+    try {
+      const res = await post({
+        endpoint: `${findIdPwApi.POST_FIND_PW}`,
+        body: {
+          ...userInfo,
+        },
+      });
+
+      if (res.data.resultCode === 'SUCCESS') {
+        window.alert('임시 비밀번호 발급이 완료되었습니다.');
+        navigate(`${LOGIN_PATH}`);
+      }
+    } catch (err) {
+      console.error(err);
+      window.alert('해당 유저 정보가 존재하지 않아요.');
+    }
+  };
+
+  const onChangeInput =
+    (target: 'username' | 'account' | 'email') => (e: ChangeEvent<HTMLInputElement>) => {
+      setUserInfo((prev) => {
+        return {
+          ...prev,
+          [target]: e.target.value,
+        };
+      });
+    };
+
+  return (
+    <>
+      <CustomHeader title='비밀번호 찾기' hideIcon />
+      <div className='password-container'>
+        <div>
+          <InputTilte isRequire>이름</InputTilte>
+          <InputBox
+            onChange={onChangeInput('username')}
+            value={userInfo.username}
+            placeholder='이름을 입력하세요.'
+          />
+        </div>
+
+        <div>
+          <InputTilte isRequire>아이디</InputTilte>
+          <InputBox
+            onChange={onChangeInput('account')}
+            value={userInfo.account}
+            placeholder='아이디를 입력하세요.'
+          />
+        </div>
+
+        <div>
+          <InputTilte isRequire>이메일</InputTilte>
+          <InputBox
+            onChange={onChangeInput('email')}
+            value={userInfo.email}
+            placeholder='이메일을 입력하세요.'
+          />
+        </div>
+        <p className='message'>
+          회원가입시 작성한 이메일로
+          <br />
+          <strong>임시 비밀번호</strong>가 발급됩니다.
+        </p>
+        <FooterButton onClick={onClickChangePassword}>확인</FooterButton>
+      </div>
+    </>
+  );
+}

--- a/src/pages/FindAccount/index.tsx
+++ b/src/pages/FindAccount/index.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button, CustomHeader } from 'components';
+
+import { FIND_ID_PATH, FIND_PW_PATH } from 'constants/routes';
+
+export default function FindAccount() {
+  const navigate = useNavigate();
+
+  const onClickFindId = () => {
+    navigate(`${FIND_ID_PATH}`);
+  };
+
+  const onClickFindPw = () => {
+    navigate(`${FIND_PW_PATH}`);
+  };
+
+  return (
+    <div>
+      <CustomHeader title='아이디/비밀번호 찾기' hideIcon />
+      <div className='find-account-container'>
+        <Button outline onClick={onClickFindId}>
+          아이디 찾기
+        </Button>
+        <Button outline onClick={onClickFindPw}>
+          비밀번호 찾기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Login/Kakao.tsx
+++ b/src/pages/Login/Kakao.tsx
@@ -1,12 +1,26 @@
-import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
-import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import axios, { AxiosError } from 'axios';
 
 import { REDIRECT_URI, KAKAO_AUTH_URI } from 'constants/kakaoLogin';
+import { socialLoginApi } from 'constants/apiEndpoint';
+import { HOME_PATH } from 'constants/routes';
+import { encryptRefreshToken } from 'utils/cryptoRefreshToken';
+
+interface ErrorResponse {
+  resultCode: string;
+  data: null | object;
+}
+
+const SERVER_URL = `${process.env.REACT_APP_API_URL}:${process.env.REACT_APP_API_PORT}/`;
 
 export default function Kakao() {
   const location = useLocation();
   const KAKAO_CODE = location.search.split('=').pop();
+
+  const [kakaoAccessToken, setKakaoAccessToken] = useState('');
+
+  const navigate = useNavigate();
 
   const getToken = async () => {
     const body = {
@@ -22,16 +36,81 @@ export default function Kakao() {
       });
 
       console.log(res.data.access_token);
+      await tryLogin(res.data.access_token);
     } catch (err) {
-      console.error(err, '카카오 소셜 로그인 에러');
+      console.error(err, '카카오 에러');
+    }
+  };
+
+  const tryLogin = async (token: string) => {
+    try {
+      const socialLoginUrl = socialLoginApi.POST_SOCIAL_LOGIN_KAKAO;
+      const res = await axios.post(
+        `${SERVER_URL}${socialLoginUrl}`,
+        {},
+        {
+          headers: { Authorization: `${token}` },
+        }
+      );
+
+      // 상태코드 200 반환 시 세션 스토리지 저장
+      // TODO: 마이페이지에서 닉네임 변경 시 리프레시 토큰이 없으므로 에러 발생할듯
+      if (res.status === 200) {
+        const accessToken = res.data.data.accessToken;
+        const refreshToken = res.data.data.refreshToken;
+
+        console.log(res);
+
+        if (accessToken) {
+          sessionStorage.setItem('userToken', accessToken);
+          // 리프레시 토큰 암호화
+          const encryptRefreshUserToken = encryptRefreshToken(refreshToken);
+          sessionStorage.setItem('refreshToken', encryptRefreshUserToken);
+
+          navigate(`${HOME_PATH}`);
+        }
+      }
+    } catch (err) {
+      const error = err as AxiosError;
+      const errorData = error.response?.data as ErrorResponse;
+      console.error(errorData.resultCode, 'error');
+      if (errorData.resultCode === 'NEED_MORE_INFO') {
+        await getUser(token);
+      }
+    }
+  };
+
+  const getUser = async (kakaoToken: string) => {
+    const body = {
+      isNotificated: true,
+      provider: 'KAKAO',
+    };
+
+    try {
+      const socialJoinUrl = socialLoginApi.POST_SOCIAL_JOIN_KAKAO;
+      const res = await axios.post(`${SERVER_URL}${socialJoinUrl}`, body, {
+        headers: { Authorization: `${kakaoToken}` },
+      });
+
+      console.log(res);
+    } catch (err) {
+      console.error(err);
     }
   };
 
   useEffect(() => {
-    if (!KAKAO_CODE) return;
+    if (!location.search && !KAKAO_CODE) return;
 
-    getToken();
-  }, [KAKAO_CODE]);
+    const authKakao = async () => {
+      await getToken();
+    };
 
-  return <>카카오 로그인</>;
+    authKakao();
+  }, [location]);
+
+  useEffect(() => {
+    if (!kakaoAccessToken) return;
+  }, []);
+
+  return <></>;
 }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -64,8 +64,6 @@ export default function Login() {
         initSessionStorageRefeshToken(refreshToken);
 
         setToken(accessToken);
-
-        alert('로그인 성공!');
         navigate(`${HOME_PATH}`);
       }
     } catch (err: unknown) {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -8,7 +8,7 @@ import { ApiError } from 'types/errorsTypes';
 
 import { KAKAO_LOGIN_URI } from 'constants/kakaoLogin';
 import { loginApi } from 'constants/apiEndpoint';
-import { HOME_PATH } from 'constants/routes';
+import { FIND_ID_PW_PATH, HOME_PATH } from 'constants/routes';
 
 import { Google, Naver, Kakao } from 'assets/login/symbols';
 import Logo from 'assets/Logo.svg';
@@ -79,6 +79,10 @@ export default function Login() {
     }
   };
 
+  const onClickFindIdPw = () => {
+    navigate(`${FIND_ID_PW_PATH}`);
+  };
+
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
@@ -114,7 +118,9 @@ export default function Login() {
           <Button>로그인</Button>
         </div>
         <div className='find-and-join-container'>
-          <span tabIndex={0}>아이디/비밀번호 찾기</span>
+          <span tabIndex={0} onClick={onClickFindIdPw}>
+            아이디/비밀번호 찾기
+          </span>
           <span className='vertical-bar'>|</span>
           <span className='join' tabIndex={0}>
             <Link to='/auth/signup'>회원가입</Link>

--- a/src/pages/MyPage/Account.tsx
+++ b/src/pages/MyPage/Account.tsx
@@ -7,7 +7,7 @@ import ButtonModal from 'components/common/ButtonModal';
 import { del } from 'utils';
 
 import { myPageApi } from 'constants/apiEndpoint';
-import { HOME_PATH, MY_PAGE_WITHDRAWAL_PATH } from 'constants/routes';
+import { HOME_PATH, MY_PAGE_CHANGE_PW, MY_PAGE_WITHDRAWAL_PATH } from 'constants/routes';
 
 const initLogoutModalText = {
   cancleText: '취소하기',
@@ -26,7 +26,11 @@ export default function Account() {
   const [showModal, setShowModal] = useState(false);
   const [logoutModalText, setLogoutModalText] = useState(initLogoutModalText);
 
-  const onClickMenuItem = (target: string) => () => {
+  const onClickMenuItem = (nav: string) => () => {
+    navigate(nav);
+  };
+
+  const onClickShowModal = (target: string) => () => {
     if (target) setShowModal(() => true);
   };
 
@@ -66,8 +70,10 @@ export default function Account() {
       <CustomHeader title='계정' />
       <div className='setting-menus'>
         <ul className='account-menus'>
-          <li role='button'>비밀번호 변경</li>
-          <li onClick={onClickMenuItem(modalTargets.logout)} role='button'>
+          <li role='button' onClick={onClickMenuItem(`${MY_PAGE_CHANGE_PW}`)}>
+            비밀번호 변경
+          </li>
+          <li onClick={onClickShowModal(modalTargets.logout)} role='button'>
             로그아웃
           </li>
           <li role='button' onClick={onClickWithdrawal}>

--- a/src/pages/MyPage/ChangePassword.tsx
+++ b/src/pages/MyPage/ChangePassword.tsx
@@ -52,22 +52,27 @@ export default function ChangePassword() {
     reEnterPassword: useRef(null),
   });
 
+  /* 비밀번호 변경 PATCH 요청 */
   const submitChangePassword = async () => {
-    try {
-      const res = await patch({
-        endpoint: myPageApi.PATCH_MY_PASSWORD,
-        isFormData: false,
-        body: {
-          password: inputPassword.password,
-        },
-      });
+    const isCorrectInputValues = Object.entries(isCorrectFormData).every(([_, value]) => value);
 
-      if (res.status === 200) {
-        setShowModal(true);
+    if (isCorrectInputValues) {
+      try {
+        const res = await patch({
+          endpoint: myPageApi.PATCH_MY_PASSWORD,
+          isFormData: false,
+          body: {
+            password: inputPassword.password,
+          },
+        });
+
+        if (res.status === 200) {
+          setShowModal(true);
+        }
+      } catch (err) {
+        console.error(err);
       }
-    } catch (err) {
-      console.error(err);
-    }
+    } else setInputsToShake(() => []);
   };
 
   const onChangeInput = (target: FieldName) => (e: ChangeEvent<HTMLInputElement>) => {
@@ -112,6 +117,8 @@ export default function ChangePassword() {
   }, []);
 
   useEffect(() => {
+    if (!inputPassword.password || !inputPassword.reEnterPassword) return;
+
     if (inputPassword.password === inputPassword.reEnterPassword) {
       setIsCorrectFormData((prev) => {
         return { ...prev, reEnterPassword: true };
@@ -125,6 +132,9 @@ export default function ChangePassword() {
     }
   }, [inputPassword.password, inputPassword.reEnterPassword]);
 
+  // TODO: shake 애니메이션 추가하기
+
+  // 경고 메시지 출력
   useEffect(() => {
     if (inputPassword.password !== inputPassword.reEnterPassword) {
       setWarningMessage((prev) => {
@@ -138,6 +148,8 @@ export default function ChangePassword() {
         };
       });
     } else {
+      if (!inputPassword.password || !inputPassword.reEnterPassword) return;
+
       setWarningMessage((prev) => {
         return { ...prev, reEnterPassword: '' };
       });

--- a/src/pages/MyPage/ChangePassword.tsx
+++ b/src/pages/MyPage/ChangePassword.tsx
@@ -1,0 +1,198 @@
+import { CustomHeader, FooterButton } from 'components';
+import Modal from 'components/common/Modal';
+import InputField from 'components/signup/InputField';
+import { myPageApi } from 'constants/apiEndpoint';
+import { MY_PAGE_PATH } from 'constants/routes';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FieldName } from 'types/signupTypes';
+import { patch } from 'utils';
+import { initWarningMessage } from 'utils/initialValues/signup';
+import { isValidPw, validatePassword, validateReEnterPassword } from 'utils/validate/checkSignup';
+
+export interface ChangeAccountInterface {
+  account?: string;
+  password: string;
+  reEnterPassword: string;
+  username?: string;
+  email?: string;
+  isNotificated?: boolean;
+}
+
+interface ChangePasswordProps {
+  password: React.RefObject<HTMLInputElement>;
+  reEnterPassword: React.RefObject<HTMLInputElement>;
+}
+
+interface ValidChecker {
+  password: boolean;
+  reEnterPassword: boolean;
+}
+
+export default function ChangePassword() {
+  const navigate = useNavigate();
+
+  const [inputPassword, setInputPassword] = useState({
+    password: '',
+    reEnterPassword: '',
+  });
+
+  const [isCorrectFormData, setIsCorrectFormData] = useState<ValidChecker>({
+    password: false,
+    reEnterPassword: false,
+  });
+
+  const [showModal, setShowModal] = useState(false);
+
+  const [inputsToShake, setInputsToShake] = useState<FieldName[]>([]);
+  const [warningMessage, setWarningMessage] = useState(initWarningMessage);
+
+  const formRefs = useRef<ChangePasswordProps>({
+    password: useRef(null),
+    reEnterPassword: useRef(null),
+  });
+
+  const submitChangePassword = async () => {
+    try {
+      const res = await patch({
+        endpoint: myPageApi.PATCH_MY_PASSWORD,
+        isFormData: false,
+        body: {
+          password: inputPassword.password,
+        },
+      });
+
+      if (res.status === 200) {
+        setShowModal(true);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const onChangeInput = (target: FieldName) => (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    setIsCorrectFormData((prev) => {
+      if (target === 'password') {
+        return {
+          ...prev,
+          [target]: false,
+          reEnterPassword: false,
+        };
+      }
+
+      return { ...prev, [target]: false };
+    });
+
+    setInputPassword((prev) => {
+      return { ...prev, [target]: value };
+    });
+
+    setWarningMessage((prev) => {
+      if (target === 'password') {
+        return { ...prev, [target]: validatePassword(value).msg };
+      }
+
+      if (target === 'reEnterPassword') {
+        const password = inputPassword.password;
+        const reEnterPassword = value;
+
+        return { ...prev, [target]: validateReEnterPassword(password, reEnterPassword).msg };
+      }
+
+      return { ...prev, [target]: '' };
+    });
+  };
+
+  useEffect(() => {
+    if (!formRefs.current) return;
+
+    formRefs.current.password.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (inputPassword.password === inputPassword.reEnterPassword) {
+      setIsCorrectFormData((prev) => {
+        return { ...prev, reEnterPassword: true };
+      });
+    }
+
+    if (isValidPw(inputPassword.password)) {
+      setIsCorrectFormData((prev) => {
+        return { ...prev, password: true };
+      });
+    }
+  }, [inputPassword.password, inputPassword.reEnterPassword]);
+
+  useEffect(() => {
+    if (inputPassword.password !== inputPassword.reEnterPassword) {
+      setWarningMessage((prev) => {
+        return { ...prev, reEnterPassword: '비밀번호가 일치하지 않아요.' };
+      });
+
+      setIsCorrectFormData(() => {
+        return {
+          password: false,
+          reEnterPassword: false,
+        };
+      });
+    } else {
+      setWarningMessage((prev) => {
+        return { ...prev, reEnterPassword: '' };
+      });
+
+      setIsCorrectFormData(() => {
+        return {
+          password: true,
+          reEnterPassword: true,
+        };
+      });
+    }
+  }, [inputPassword.password]);
+
+  return (
+    <>
+      {showModal && (
+        <Modal
+          closeModal={() => {
+            setShowModal(false);
+            navigate(`${MY_PAGE_PATH}`);
+          }}
+        >
+          <h2 className='modal-title'>비밀번호 변경</h2>
+          <p className='modal-content'>변경이 완료되었어요.</p>
+        </Modal>
+      )}
+      <CustomHeader title='비밀번호 변경' hideIcon />
+      <div className='change-password-container'>
+        <InputField
+          inputRef={formRefs.current.password}
+          onChange={onChangeInput}
+          className={`${inputsToShake.includes('password') ? 'shake' : ''}`}
+          placeholder='새로운 비밀번호를 입력해주세요.'
+          type='password'
+          target='password'
+          title='새 비밀번호'
+          registrationMembership={inputPassword}
+          initWarningMessage={initWarningMessage}
+          warningMessage={warningMessage}
+        />
+
+        <InputField
+          inputRef={formRefs.current.reEnterPassword}
+          onChange={onChangeInput}
+          className={`${inputsToShake.includes('reEnterPassword') ? 'shake' : ''}`}
+          placeholder='비밀번호를 다시 입력해주세요.'
+          type='password'
+          target='reEnterPassword'
+          title='비밀번호 확인'
+          registrationMembership={inputPassword}
+          initWarningMessage={initWarningMessage}
+          warningMessage={warningMessage}
+        />
+        <FooterButton onClick={submitChangePassword}>변경하기</FooterButton>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Notification/index.tsx
+++ b/src/pages/Notification/index.tsx
@@ -1,0 +1,3 @@
+export default function Notification() {
+  return <>준비중이에요! 🙇</>;
+}

--- a/src/pages/PetProfileEditor/index.tsx
+++ b/src/pages/PetProfileEditor/index.tsx
@@ -250,12 +250,15 @@ export default function PetProfileEditor() {
   useEffect(() => {
     setIsMounted(true);
 
+    if (!petProfile?.name) return;
+
     const nameRef = inputRefs.current.name.current;
     if (nameRef) {
-      nameRef.value = petProfile?.name;
+      nameRef.selectionStart = petProfile.name.length;
+      nameRef.selectionEnd = petProfile.name.length;
       nameRef.focus();
     }
-  }, []);
+  }, [isMounted, petProfile.name]);
 
   const focusInput = (inputName: RequiredValues) => {
     if (inputsToShake.includes(inputName)) return;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -22,3 +22,5 @@ export const KakaoLogin = lazy(() => import('./Login/Kakao'));
 export const Account = lazy(() => import('./MyPage/Account'));
 export const Withdrawal = lazy(() => import('./MyPage/Withdrawal'));
 export const NotFound = lazy(() => import('./NotFound'));
+export const Notification = lazy(() => import('./Notification'));
+export const Bookmark = lazy(() => import('./Bookmark'));

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -25,3 +25,6 @@ export const NotFound = lazy(() => import('./NotFound'));
 export const Notification = lazy(() => import('./Notification'));
 export const Bookmark = lazy(() => import('./Bookmark'));
 export const ChangeMyPassword = lazy(() => import('./MyPage/ChangePassword'));
+export const FindIdPw = lazy(() => import('./FindAccount'));
+export const FindId = lazy(() => import('./FindAccount/Id'));
+export const FindPw = lazy(() => import('./FindAccount/Password'));

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -24,3 +24,4 @@ export const Withdrawal = lazy(() => import('./MyPage/Withdrawal'));
 export const NotFound = lazy(() => import('./NotFound'));
 export const Notification = lazy(() => import('./Notification'));
 export const Bookmark = lazy(() => import('./Bookmark'));
+export const ChangeMyPassword = lazy(() => import('./MyPage/ChangePassword'));

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -40,6 +40,7 @@ import {
   EXPERT_PATH,
   getPathModificationExpertProfile,
   BOOKMARK,
+  MY_PAGE_CHANGE_PW,
 } from 'constants/routes';
 import { TOKEN_KEY } from 'constants/token';
 
@@ -254,6 +255,7 @@ export default function Router() {
           />
 
           <Route path={MY_PAGE_ACCOUNT_PATH} element={<pages.Account />} />
+          <Route path={MY_PAGE_CHANGE_PW} element={<pages.ChangeMyPassword />} />
           <Route path={MY_PAGE_WITHDRAWAL_PATH} element={<pages.Withdrawal />} />
 
           {/* 내 프로필 수정 */}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -283,9 +283,9 @@ function ShowModalExpertOnly({
     <ButtonModal
       cancleText='메인으로'
       confirmText='이전 페이지'
-      closeModal={() => closeModal}
-      onCancle={() => onCancle}
-      onConfirm={() => onConfirm}
+      closeModal={() => closeModal()}
+      onCancle={() => onCancle()}
+      onConfirm={() => onConfirm()}
       children={
         <>
           <h2 className='modal-title'>잘못된 접근</h2>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -41,6 +41,9 @@ import {
   getPathModificationExpertProfile,
   BOOKMARK,
   MY_PAGE_CHANGE_PW,
+  FIND_ID_PW_PATH,
+  FIND_ID_PATH,
+  FIND_PW_PATH,
 } from 'constants/routes';
 import { TOKEN_KEY } from 'constants/token';
 
@@ -144,6 +147,9 @@ export default function Router() {
               <Route path={LOGIN_PATH} element={<pages.Login />} />
               <Route path={JOIN_PATH} element={<pages.Signup />} />
               <Route path={KAKAO_AUTH_PATH} element={<pages.KakaoLogin />} />
+              <Route path={FIND_ID_PW_PATH} element={<pages.FindIdPw />} />
+              <Route path={FIND_ID_PATH} element={<pages.FindId />} />
+              <Route path={FIND_PW_PATH} element={<pages.FindPw />} />
             </Route>
 
             <Route path='*' element={<Navigate to={HOME_PATH} />} />

--- a/src/styles/components/_button-modal.scss
+++ b/src/styles/components/_button-modal.scss
@@ -15,6 +15,10 @@
     margin-bottom: 1rem;
   }
 
+  .modal-content {
+    margin-bottom: 10px;
+  }
+
   a {
     color: $primary-color;
   }

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -18,10 +18,25 @@
 }
 
 .modal-box {
+  @include center;
+  flex-direction: column;
   background-color: white;
   padding: 25px;
   border-radius: 10px;
+  min-width: 250px;
+  min-height: 150px;
   max-width: 300px;
+
+  .modal-title {
+    font-size: 1.8rem;
+    font-weight: 600;
+    text-align: center;
+  }
+
+  .modal-content {
+    font-size: 1.5rem;
+    text-align: center;
+  }
 
   h2 {
     color: $primary-color;

--- a/src/styles/pages/_changePassword.scss
+++ b/src/styles/pages/_changePassword.scss
@@ -1,0 +1,24 @@
+@use '../abstracts' as *;
+
+.change-password-container {
+  @include header-gap;
+  max-width: 500px;
+  width: 100%;
+  padding: 2rem;
+
+  .title-message {
+    display: flex;
+    align-items: flex-end;
+    gap: 2rem;
+    width: 100%;
+    margin-bottom: 10px;
+  }
+
+  .warning-message {
+    font-size: 1.1rem;
+  }
+
+  span:last-child {
+    margin-top: 2rem;
+  }
+}

--- a/src/styles/pages/_find-account.scss
+++ b/src/styles/pages/_find-account.scss
@@ -1,0 +1,8 @@
+@use '../abstracts' as *;
+
+.find-account-container {
+  @include header-gap;
+  @include center;
+  flex-direction: column;
+  gap: 2rem;
+}

--- a/src/styles/pages/_id.scss
+++ b/src/styles/pages/_id.scss
@@ -1,0 +1,40 @@
+@use '../abstracts' as *;
+
+.find-id-container {
+  @include header-gap;
+  @include center;
+  flex-direction: column;
+  gap: 2rem;
+  min-width: 70%;
+  max-width: 300px;
+
+  .input-title {
+    margin-bottom: 1rem;
+  }
+
+  .message-result {
+    margin-top: 5rem;
+    text-align: center;
+    font-size: 1.3rem;
+
+    p {
+      margin-top: 1rem;
+    }
+
+    p:first-child {
+      font-weight: 600;
+    }
+
+    p:last-child {
+      color: $primary-color;
+    }
+  }
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    width: 100%;
+  }
+}

--- a/src/styles/pages/_password.scss
+++ b/src/styles/pages/_password.scss
@@ -1,0 +1,31 @@
+@use '../abstracts' as *;
+
+.password-container {
+  @include header-gap;
+  @include center;
+  flex-direction: column;
+  gap: 2rem;
+  min-width: 70%;
+  max-width: 300px;
+
+  .input-title {
+    margin-bottom: 1rem;
+  }
+
+  .message {
+    margin-top: 2rem;
+    line-height: 1.8rem;
+  }
+
+  strong {
+    font-weight: 600;
+  }
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    width: 100%;
+  }
+}

--- a/src/styles/pages/index.scss
+++ b/src/styles/pages/index.scss
@@ -19,3 +19,4 @@
 @forward 'changePassword';
 @forward 'find-account';
 @forward 'id';
+@forward 'password';

--- a/src/styles/pages/index.scss
+++ b/src/styles/pages/index.scss
@@ -17,3 +17,5 @@
 @forward 'withdrawal';
 @forward 'not-found';
 @forward 'changePassword';
+@forward 'find-account';
+@forward 'id';

--- a/src/styles/pages/index.scss
+++ b/src/styles/pages/index.scss
@@ -16,3 +16,4 @@
 @forward 'account';
 @forward 'withdrawal';
 @forward 'not-found';
+@forward 'changePassword';

--- a/src/types/expertProfileTypes.ts
+++ b/src/types/expertProfileTypes.ts
@@ -5,4 +5,5 @@ export interface Profile {
   introduce?: string;
   location?: string;
   imagePath?: string;
+  expertId?: number;
 }

--- a/src/types/expertProfileTypes.ts
+++ b/src/types/expertProfileTypes.ts
@@ -4,4 +4,5 @@ export interface Profile {
   careerList?: string[];
   introduce?: string;
   location?: string;
+  imagePath?: string;
 }

--- a/src/utils/checkExtensions.ts
+++ b/src/utils/checkExtensions.ts
@@ -1,9 +1,12 @@
 const ALLOWED_FILE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
 
-export default function checkExtensions(files: FileList) {
+export default function checkExtensions(
+  files: FileList,
+  allowedExtensions = ALLOWED_FILE_EXTENSIONS
+) {
   for (const file of [...files]) {
     const extensions = file.name.split('.').pop()?.toLocaleLowerCase();
-    if (extensions && !ALLOWED_FILE_EXTENSIONS.includes(extensions)) return false;
+    if (extensions && !allowedExtensions.includes(extensions)) return false;
     return true;
   }
 }


### PR DESCRIPTION
## 기능 구현 사항

**- 소셜 로그인 (카카오)**
해당 기능은 처음 구현해봐서 테스트 계속 해봐야 할 것 같아요.
회원가입이 완료된 소셜 계정은 버튼 클릭 시 바로 로그인 처리됩니다.

![Honeycam 2023-04-20 12-32-12](https://user-images.githubusercontent.com/48672106/233251471-5a9e84c5-19c4-4e76-b2d6-b0f87e811ed5.gif)


**- 전문가 프로필 수정하기**
현재 전문가 프로필 등록 여부를 서버에서 전달받지 못하므로 마이페이지에서는 등록하기 메뉴만 노출되므로 첫 등록인지, 수정인지 여부를 확인할 수 없다는 문제가 있으나 기능 구현이라도 먼저 해놓기 위해서 전문가 프로필 보기 페이지에서 본인의 프로필인 경우 하단 버튼을 노출시켜 수정이 가능하도록 구현해놓았습니다.

![Honeycam 2023-04-20 12-31-34](https://user-images.githubusercontent.com/48672106/233251407-130c9bd5-d3bf-493c-99c3-dcdf7939becd.gif)


**- 비밀번호 변경**
마이페이지에서 비밀번호 변경을 수행할 수 있습니다.
다만, 해당 기능은 아직 예외처리가 제대로 되어있지 않습니다.

![Honeycam 2023-04-20 11-58-04](https://user-images.githubusercontent.com/48672106/233248089-6806e0b4-30b0-4380-a695-551d8018b1c3.gif)


**- 아이디/비밀번호 찾기**
아이디 찾기의 경우 API가 없어서 레이아웃만 구성되어있습니다.
따라서  **비밀번호 찾기 페이지만 구현**되어 있습니다.
비밀번호 찾기 할 때 `서버 통신이 지연`되는데 체크를 해봐야 할 것 같아요.
비밀번호 찾기 요청 시 가입한 이메일로 임시 비밀번호 6자리가 전송되는 것을 확인했습니다.

![image](https://user-images.githubusercontent.com/48672106/233248010-07cce455-3922-4dff-825c-c74a790b28a2.png)

비밀번호 발급 이메일 본문입니다.


## 예상되는 이슈

- 비밀번호 찾기: 초기 회원가입 시 이메일 인증을 거치지 않기 때문에 본인의 이메일로 가입하지 않은 경우 문제가 발생할 수 있습니다.
따라서 추후 개선 가능하다면 이메일 인증을 거치는 방법을 통해 유효 이메일을 체크하는 방법이 좋을 것 같아요.

- 소셜 로그인: 카카오 계정과 회원가입 시 이메일이 동일한 경우 서버에서 에러가 발생하는 것으로 확인했습니다.
